### PR TITLE
feat: subscriptions CRUD + real Chzzk OAuth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testRuntimeOnly 'com.h2database:h2'
 }
 

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/config/ChzzkOAuthProperties.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/config/ChzzkOAuthProperties.java
@@ -1,0 +1,17 @@
+package me.cocoblue.chzzkeventtodiscord.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "chzzk.oauth")
+public class ChzzkOAuthProperties {
+    private String authBaseUrl = "https://chzzk.naver.com";
+    private String tokenBaseUrl = "https://openapi.chzzk.naver.com";
+    private String apiBaseUrl = "https://openapi.chzzk.naver.com";
+    private String clientId = "";
+    private String clientSecret = "";
+    private String redirectUri = "";
+}

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/config/SecurityConfig.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/config/SecurityConfig.java
@@ -19,6 +19,7 @@ public class SecurityConfig {
             .formLogin(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/auth/chzzk/login", "/api/v1/auth/chzzk/callback").permitAll()
+                .requestMatchers("/api/v1/subscriptions/**").authenticated()
                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/**").authenticated()
                 .anyRequest().permitAll()

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/controller/AuthController.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/controller/AuthController.java
@@ -43,12 +43,9 @@ public class AuthController {
     public ResponseEntity<AuthUserResponse> handleChzzkCallback(
         @RequestParam(required = false) String code,
         @RequestParam(required = false) String state,
-        @RequestParam(required = false) String mockChannelId,
-        @RequestParam(required = false) AppRole mockRole,
         HttpServletRequest request
     ) {
-        final ChzzkPrincipal principal =
-            chzzkAuthService.authenticateFromCallback(code, state, mockChannelId, mockRole);
+        final ChzzkPrincipal principal = chzzkAuthService.authenticateFromCallback(code, state);
 
         final UsernamePasswordAuthenticationToken authentication =
             new UsernamePasswordAuthenticationToken(principal, null, principal.authorities());

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/controller/SubscriptionController.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/controller/SubscriptionController.java
@@ -1,0 +1,100 @@
+package me.cocoblue.chzzkeventtodiscord.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.cocoblue.chzzkeventtodiscord.dto.subscription.SubscriptionRequestDto;
+import me.cocoblue.chzzkeventtodiscord.dto.subscription.SubscriptionResponseDto;
+import me.cocoblue.chzzkeventtodiscord.security.AppRole;
+import me.cocoblue.chzzkeventtodiscord.security.ChzzkPrincipal;
+import me.cocoblue.chzzkeventtodiscord.service.SubscriptionCrudService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/subscriptions")
+@RequiredArgsConstructor
+public class SubscriptionController {
+    private final SubscriptionCrudService subscriptionCrudService;
+
+    @PostMapping
+    public ResponseEntity<SubscriptionResponseDto> create(
+        @RequestBody SubscriptionRequestDto request,
+        Authentication authentication
+    ) {
+        final ChzzkPrincipal principal = extractPrincipal(authentication);
+        final SubscriptionResponseDto response = SubscriptionResponseDto.fromEntity(
+            subscriptionCrudService.create(request, principal)
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<SubscriptionResponseDto>> list(Pageable pageable, Authentication authentication) {
+        final ChzzkPrincipal principal = extractPrincipal(authentication);
+        final Page<SubscriptionResponseDto> response = subscriptionCrudService.list(principal, pageable)
+            .map(SubscriptionResponseDto::fromEntity);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{subscriptionId}")
+    public ResponseEntity<SubscriptionResponseDto> get(
+        @PathVariable Long subscriptionId,
+        Authentication authentication
+    ) {
+        final ChzzkPrincipal principal = extractPrincipal(authentication);
+        final SubscriptionResponseDto response = SubscriptionResponseDto.fromEntity(
+            subscriptionCrudService.get(subscriptionId, principal)
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{subscriptionId}")
+    public ResponseEntity<SubscriptionResponseDto> update(
+        @PathVariable Long subscriptionId,
+        @RequestBody SubscriptionRequestDto request,
+        Authentication authentication
+    ) {
+        final ChzzkPrincipal principal = extractPrincipal(authentication);
+        final SubscriptionResponseDto response = SubscriptionResponseDto.fromEntity(
+            subscriptionCrudService.update(subscriptionId, request, principal)
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{subscriptionId}")
+    public ResponseEntity<Void> delete(
+        @PathVariable Long subscriptionId,
+        Authentication authentication
+    ) {
+        final ChzzkPrincipal principal = extractPrincipal(authentication);
+        subscriptionCrudService.delete(subscriptionId, principal);
+        return ResponseEntity.noContent().build();
+    }
+
+    private ChzzkPrincipal extractPrincipal(Authentication authentication) {
+        final Object principalObject = authentication.getPrincipal();
+        if (principalObject instanceof ChzzkPrincipal chzzkPrincipal) {
+            return chzzkPrincipal;
+        }
+
+        final AppRole role = authentication.getAuthorities().stream()
+            .anyMatch(authority -> "ROLE_ADMIN".equals(authority.getAuthority()))
+            ? AppRole.ADMIN
+            : AppRole.USER;
+        return new ChzzkPrincipal(authentication.getName(), role);
+    }
+}

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/domain/chzzk/ChzzkOAuthTokenEntity.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/domain/chzzk/ChzzkOAuthTokenEntity.java
@@ -1,0 +1,50 @@
+package me.cocoblue.chzzkeventtodiscord.domain.chzzk;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "chzzk_oauth_token")
+public class ChzzkOAuthTokenEntity {
+    @Id
+    @Column(name = "channel_id", nullable = false, length = 100)
+    private String channelId;
+
+    @Column(name = "access_token", nullable = false, length = 3000)
+    private String accessToken;
+
+    @Column(name = "refresh_token", length = 3000)
+    private String refreshToken;
+
+    @Column(name = "token_type", length = 30)
+    private String tokenType;
+
+    @Column(name = "scope", length = 1000)
+    private String scope;
+
+    @Column(name = "access_token_expires_at")
+    private ZonedDateTime accessTokenExpiresAt;
+
+    @Column(name = "refresh_token_expires_at")
+    private ZonedDateTime refreshTokenExpiresAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private ZonedDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private ZonedDateTime updatedAt;
+}

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/domain/chzzk/ChzzkOAuthTokenRepository.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/domain/chzzk/ChzzkOAuthTokenRepository.java
@@ -1,0 +1,8 @@
+package me.cocoblue.chzzkeventtodiscord.domain.chzzk;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChzzkOAuthTokenRepository extends JpaRepository<ChzzkOAuthTokenEntity, String> {
+}

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/domain/chzzk/ChzzkSubscriptionFormRepository.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/domain/chzzk/ChzzkSubscriptionFormRepository.java
@@ -2,9 +2,12 @@ package me.cocoblue.chzzkeventtodiscord.domain.chzzk;
 
 import me.cocoblue.chzzkeventtodiscord.data.chzzk.ChzzkSubscriptionType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChzzkSubscriptionFormRepository extends JpaRepository<ChzzkSubscriptionFormEntity, Long> {
@@ -14,4 +17,8 @@ public interface ChzzkSubscriptionFormRepository extends JpaRepository<ChzzkSubs
     List<ChzzkSubscriptionFormEntity> findAllByChzzkChannelEntityAndEnabled(ChzzkChannelEntity chzzkChannelEntity, boolean enabled);
 
     List<ChzzkSubscriptionFormEntity> findAllByEnabled(boolean enabled);
+
+    Page<ChzzkSubscriptionFormEntity> findAllByFormOwner_ChannelId(String channelId, Pageable pageable);
+
+    Optional<ChzzkSubscriptionFormEntity> findByIdAndFormOwner_ChannelId(Long id, String channelId);
 }

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/dto/subscription/SubscriptionRequestDto.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/dto/subscription/SubscriptionRequestDto.java
@@ -1,0 +1,23 @@
+package me.cocoblue.chzzkeventtodiscord.dto.subscription;
+
+import lombok.Data;
+import me.cocoblue.chzzkeventtodiscord.data.LanguageIsoData;
+import me.cocoblue.chzzkeventtodiscord.data.chzzk.ChzzkSubscriptionType;
+
+@Data
+public class SubscriptionRequestDto {
+    private String channelId;
+    private String formOwnerChannelId;
+    private ChzzkSubscriptionType subscriptionType;
+    private Long webhookId;
+    private Long botProfileId;
+    private LanguageIsoData language;
+    private Integer intervalMinute;
+    private Boolean enabled;
+    private String content;
+    private String colorHex;
+    private Boolean showDetail;
+    private Boolean showThumbnail;
+    private Boolean showViewerCount;
+    private Boolean showTag;
+}

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/dto/subscription/SubscriptionResponseDto.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/dto/subscription/SubscriptionResponseDto.java
@@ -1,0 +1,51 @@
+package me.cocoblue.chzzkeventtodiscord.dto.subscription;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkStreamOnlineFormEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkSubscriptionFormEntity;
+
+import java.time.ZonedDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SubscriptionResponseDto(
+    Long id,
+    String channelId,
+    String formOwnerChannelId,
+    String subscriptionType,
+    Long webhookId,
+    Long botProfileId,
+    String language,
+    Integer intervalMinute,
+    Boolean enabled,
+    String content,
+    String colorHex,
+    Boolean showDetail,
+    Boolean showThumbnail,
+    Boolean showViewerCount,
+    Boolean showTag,
+    ZonedDateTime createdAt
+) {
+    public static SubscriptionResponseDto fromEntity(ChzzkSubscriptionFormEntity entity) {
+        final ChzzkStreamOnlineFormEntity streamOnlineForm =
+            entity instanceof ChzzkStreamOnlineFormEntity so ? so : null;
+
+        return new SubscriptionResponseDto(
+            entity.getId(),
+            entity.getChzzkChannelEntity().getChannelId(),
+            entity.getFormOwner().getChannelId(),
+            entity.getChzzkSubscriptionType().name(),
+            entity.getWebhookId().getId(),
+            entity.getBotProfileId().getId(),
+            entity.getLanguageIsoData().name(),
+            entity.getIntervalMinute(),
+            entity.isEnabled(),
+            entity.getContent(),
+            entity.getColorHex(),
+            streamOnlineForm == null ? null : streamOnlineForm.isShowDetail(),
+            streamOnlineForm == null ? null : streamOnlineForm.isShowThumbnail(),
+            streamOnlineForm == null ? null : streamOnlineForm.isShowViewerCount(),
+            streamOnlineForm == null ? null : streamOnlineForm.isShowTag(),
+            entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/me/cocoblue/chzzkeventtodiscord/service/SubscriptionCrudService.java
+++ b/src/main/java/me/cocoblue/chzzkeventtodiscord/service/SubscriptionCrudService.java
@@ -1,0 +1,284 @@
+package me.cocoblue.chzzkeventtodiscord.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import me.cocoblue.chzzkeventtodiscord.data.LanguageIsoData;
+import me.cocoblue.chzzkeventtodiscord.data.chzzk.ChzzkSubscriptionType;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkChannelEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkChannelRepository;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkStreamOnlineFormEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkSubscriptionFormEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkSubscriptionFormRepository;
+import me.cocoblue.chzzkeventtodiscord.domain.discord.DiscordBotProfileDataEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.discord.DiscordBotProfileDataRepository;
+import me.cocoblue.chzzkeventtodiscord.domain.discord.DiscordWebhookDataEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.discord.DiscordWebhookDataRepository;
+import me.cocoblue.chzzkeventtodiscord.dto.subscription.SubscriptionRequestDto;
+import me.cocoblue.chzzkeventtodiscord.security.AppRole;
+import me.cocoblue.chzzkeventtodiscord.security.ChzzkPrincipal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Objects;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class SubscriptionCrudService {
+    private static final int DEFAULT_INTERVAL_MINUTE = 10;
+    private static final String DEFAULT_COLOR_HEX = "000000";
+
+    private final ChzzkSubscriptionFormRepository subscriptionFormRepository;
+    private final ChzzkChannelRepository chzzkChannelRepository;
+    private final DiscordWebhookDataRepository discordWebhookDataRepository;
+    private final DiscordBotProfileDataRepository discordBotProfileDataRepository;
+
+    @Transactional
+    public ChzzkSubscriptionFormEntity create(SubscriptionRequestDto request, ChzzkPrincipal principal) {
+        final String ownerChannelId = resolveOwnerChannelId(request.getFormOwnerChannelId(), principal, false);
+        final ChzzkChannelEntity targetChannel = resolveChannel(request.getChannelId(), "channelId");
+        final ChzzkChannelEntity ownerChannel = resolveChannel(ownerChannelId, "formOwnerChannelId");
+        final DiscordWebhookDataEntity webhook = resolveWebhook(request.getWebhookId(), ownerChannelId, principal);
+        final DiscordBotProfileDataEntity botProfile = resolveBotProfile(request.getBotProfileId(), ownerChannelId, principal);
+        final ChzzkSubscriptionType subscriptionType = requireSubscriptionType(request.getSubscriptionType());
+
+        final ChzzkSubscriptionFormEntity entity;
+        if (subscriptionType == ChzzkSubscriptionType.STREAM_ONLINE) {
+            entity = ChzzkStreamOnlineFormEntity.builder()
+                .showDetail(Boolean.TRUE.equals(request.getShowDetail()))
+                .showThumbnail(request.getShowThumbnail() == null || request.getShowThumbnail())
+                .showViewerCount(Boolean.TRUE.equals(request.getShowViewerCount()))
+                .showTag(request.getShowTag() == null || request.getShowTag())
+                .build();
+        } else {
+            entity = new ChzzkSubscriptionFormEntity();
+        }
+
+        applyCommonFields(entity, request, targetChannel, ownerChannel, webhook, botProfile, subscriptionType, false);
+        return subscriptionFormRepository.saveAndFlush(entity);
+    }
+
+    @Transactional
+    public Page<ChzzkSubscriptionFormEntity> list(ChzzkPrincipal principal, Pageable pageable) {
+        if (principal.role() == AppRole.ADMIN) {
+            return subscriptionFormRepository.findAll(pageable);
+        }
+        return subscriptionFormRepository.findAllByFormOwner_ChannelId(principal.channelId(), pageable);
+    }
+
+    @Transactional
+    public ChzzkSubscriptionFormEntity get(Long id, ChzzkPrincipal principal) {
+        final ChzzkSubscriptionFormEntity entity = findById(id);
+        ensureReadable(entity, principal);
+        return entity;
+    }
+
+    @Transactional
+    public ChzzkSubscriptionFormEntity update(Long id, SubscriptionRequestDto request, ChzzkPrincipal principal) {
+        final ChzzkSubscriptionFormEntity entity = findById(id);
+        ensureWritable(entity, principal);
+
+        final ChzzkSubscriptionType nextType = request.getSubscriptionType() == null
+            ? entity.getChzzkSubscriptionType()
+            : request.getSubscriptionType();
+        ensureTypeIsNotMutatedAcrossHierarchy(entity, nextType);
+
+        final String ownerChannelId = resolveOwnerChannelId(request.getFormOwnerChannelId(), principal, true);
+        final ChzzkChannelEntity targetChannel = request.getChannelId() == null
+            ? entity.getChzzkChannelEntity()
+            : resolveChannel(request.getChannelId(), "channelId");
+        final ChzzkChannelEntity ownerChannel = ownerChannelId == null
+            ? entity.getFormOwner()
+            : resolveChannel(ownerChannelId, "formOwnerChannelId");
+        final DiscordWebhookDataEntity webhook = request.getWebhookId() == null
+            ? entity.getWebhookId()
+            : resolveWebhook(request.getWebhookId(), ownerChannelId, principal);
+        final DiscordBotProfileDataEntity botProfile = request.getBotProfileId() == null
+            ? entity.getBotProfileId()
+            : resolveBotProfile(request.getBotProfileId(), ownerChannelId, principal);
+
+        applyCommonFields(entity, request, targetChannel, ownerChannel, webhook, botProfile, nextType, true);
+        if (entity instanceof ChzzkStreamOnlineFormEntity streamOnlineEntity) {
+            if (request.getShowDetail() != null) {
+                streamOnlineEntity.setShowDetail(request.getShowDetail());
+            }
+            if (request.getShowThumbnail() != null) {
+                streamOnlineEntity.setShowThumbnail(request.getShowThumbnail());
+            }
+            if (request.getShowViewerCount() != null) {
+                streamOnlineEntity.setShowViewerCount(request.getShowViewerCount());
+            }
+            if (request.getShowTag() != null) {
+                streamOnlineEntity.setShowTag(request.getShowTag());
+            }
+        }
+
+        return subscriptionFormRepository.saveAndFlush(entity);
+    }
+
+    @Transactional
+    public void delete(Long id, ChzzkPrincipal principal) {
+        final ChzzkSubscriptionFormEntity entity = findById(id);
+        ensureWritable(entity, principal);
+        subscriptionFormRepository.delete(entity);
+    }
+
+    private ChzzkSubscriptionFormEntity findById(Long id) {
+        return subscriptionFormRepository.findById(id)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "subscription not found"));
+    }
+
+    private void ensureReadable(ChzzkSubscriptionFormEntity entity, ChzzkPrincipal principal) {
+        if (principal.role() == AppRole.ADMIN) {
+            return;
+        }
+        if (!Objects.equals(entity.getFormOwner().getChannelId(), principal.channelId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "subscription not owned by authenticated user");
+        }
+    }
+
+    private void ensureWritable(ChzzkSubscriptionFormEntity entity, ChzzkPrincipal principal) {
+        ensureReadable(entity, principal);
+    }
+
+    private String resolveOwnerChannelId(String requestedOwnerChannelId, ChzzkPrincipal principal, boolean isUpdate) {
+        if (principal.role() == AppRole.ADMIN) {
+            if (StringUtils.hasText(requestedOwnerChannelId)) {
+                return requestedOwnerChannelId;
+            }
+            if (isUpdate) {
+                return null;
+            }
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "formOwnerChannelId is required");
+        }
+
+        if (StringUtils.hasText(requestedOwnerChannelId) && !Objects.equals(requestedOwnerChannelId, principal.channelId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "formOwnerChannelId does not match authenticated user");
+        }
+        return principal.channelId();
+    }
+
+    private ChzzkChannelEntity resolveChannel(String channelId, String fieldName) {
+        if (!StringUtils.hasText(channelId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + " is required");
+        }
+        return chzzkChannelRepository.findById(channelId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, fieldName + " not found"));
+    }
+
+    private DiscordWebhookDataEntity resolveWebhook(Long webhookId, String ownerChannelId, ChzzkPrincipal principal) {
+        if (webhookId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "webhookId is required");
+        }
+
+        final DiscordWebhookDataEntity webhook = discordWebhookDataRepository.findById(webhookId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "webhook not found"));
+        ensureRelatedResourceOwner(webhook.getOwnerId().getChannelId(), ownerChannelId, principal, "webhook");
+        return webhook;
+    }
+
+    private DiscordBotProfileDataEntity resolveBotProfile(Long botProfileId, String ownerChannelId, ChzzkPrincipal principal) {
+        if (botProfileId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "botProfileId is required");
+        }
+
+        final DiscordBotProfileDataEntity botProfile = discordBotProfileDataRepository.findById(botProfileId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "botProfile not found"));
+        ensureRelatedResourceOwner(botProfile.getOwnerId().getChannelId(), ownerChannelId, principal, "botProfile");
+        return botProfile;
+    }
+
+    private void ensureRelatedResourceOwner(String actualOwnerChannelId, String expectedOwnerChannelId, ChzzkPrincipal principal, String resourceName) {
+        if (principal.role() == AppRole.ADMIN) {
+            return;
+        }
+        if (!Objects.equals(actualOwnerChannelId, expectedOwnerChannelId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, resourceName + " does not belong to authenticated owner");
+        }
+    }
+
+    private ChzzkSubscriptionType requireSubscriptionType(ChzzkSubscriptionType subscriptionType) {
+        if (subscriptionType == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "subscriptionType is required");
+        }
+        return subscriptionType;
+    }
+
+    private void ensureTypeIsNotMutatedAcrossHierarchy(ChzzkSubscriptionFormEntity entity, ChzzkSubscriptionType nextType) {
+        final boolean currentlyStreamOnline = entity instanceof ChzzkStreamOnlineFormEntity;
+        final boolean requestedStreamOnline = nextType == ChzzkSubscriptionType.STREAM_ONLINE;
+        if (currentlyStreamOnline != requestedStreamOnline) {
+            throw new ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "subscriptionType cannot move between STREAM_ONLINE and non-STREAM_ONLINE"
+            );
+        }
+    }
+
+    private void applyCommonFields(
+        ChzzkSubscriptionFormEntity entity,
+        SubscriptionRequestDto request,
+        ChzzkChannelEntity targetChannel,
+        ChzzkChannelEntity ownerChannel,
+        DiscordWebhookDataEntity webhook,
+        DiscordBotProfileDataEntity botProfile,
+        ChzzkSubscriptionType subscriptionType,
+        boolean keepExistingOnNull
+    ) {
+        entity.setChzzkChannelEntity(targetChannel);
+        entity.setFormOwner(ownerChannel);
+        entity.setWebhookId(webhook);
+        entity.setBotProfileId(botProfile);
+        entity.setChzzkSubscriptionType(subscriptionType);
+        entity.setIntervalMinute(resolveInterval(request.getIntervalMinute(), entity.getIntervalMinute(), keepExistingOnNull));
+        entity.setLanguageIsoData(resolveLanguage(request.getLanguage(), entity.getLanguageIsoData(), keepExistingOnNull));
+        entity.setEnabled(resolveEnabled(request.getEnabled(), entity.isEnabled(), keepExistingOnNull));
+        entity.setColorHex(resolveColorHex(request.getColorHex(), entity.getColorHex(), keepExistingOnNull));
+        entity.setContent(keepExistingOnNull && request.getContent() == null ? entity.getContent() : request.getContent());
+    }
+
+    private int resolveInterval(Integer requestValue, int existingValue, boolean keepExistingOnNull) {
+        if (requestValue != null) {
+            return requestValue;
+        }
+        if (keepExistingOnNull) {
+            return existingValue;
+        }
+        return DEFAULT_INTERVAL_MINUTE;
+    }
+
+    private LanguageIsoData resolveLanguage(LanguageIsoData requestValue, LanguageIsoData existingValue, boolean keepExistingOnNull) {
+        if (requestValue != null) {
+            return requestValue;
+        }
+        if (keepExistingOnNull && existingValue != null) {
+            return existingValue;
+        }
+        return LanguageIsoData.Korean;
+    }
+
+    private boolean resolveEnabled(Boolean requestValue, boolean existingValue, boolean keepExistingOnNull) {
+        if (requestValue != null) {
+            return requestValue;
+        }
+        if (keepExistingOnNull) {
+            return existingValue;
+        }
+        return true;
+    }
+
+    private String resolveColorHex(String requestValue, String existingValue, boolean keepExistingOnNull) {
+        if (StringUtils.hasText(requestValue)) {
+            return requestValue;
+        }
+        if (keepExistingOnNull && StringUtils.hasText(existingValue)) {
+            return existingValue;
+        }
+        return DEFAULT_COLOR_HEX;
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -32,6 +32,13 @@ spring:
 chzzk:
   check-interval: 120
   api-url: ${CHZZK_API_URL:null}
+  oauth:
+    auth-base-url: https://chzzk.naver.com
+    token-base-url: http://localhost:65535
+    api-base-url: http://localhost:65535
+    client-id: test-client-id
+    client-secret: test-client-secret
+    redirect-uri: https://example.test/callback
 
 app:
   default-timezone: "Asia/Seoul"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,13 @@ spring:
 chzzk:
   check-interval: ${CHZZK_CHECK_INTERVAL:30}
   api-url: ${CHZZK_API_URL:null}
+  oauth:
+    auth-base-url: ${CHZZK_OAUTH_AUTH_BASE_URL:https://chzzk.naver.com}
+    token-base-url: ${CHZZK_OAUTH_TOKEN_BASE_URL:https://openapi.chzzk.naver.com}
+    api-base-url: ${CHZZK_OAUTH_API_BASE_URL:https://openapi.chzzk.naver.com}
+    client-id: ${CHZZK_OAUTH_CLIENT_ID:}
+    client-secret: ${CHZZK_OAUTH_CLIENT_SECRET:}
+    redirect-uri: ${CHZZK_OAUTH_REDIRECT_URI:}
 
 app:
   default-timezone: ${APP_DEFAULT_TIMEZONE:Asia/Seoul}

--- a/src/test/java/me/cocoblue/chzzkeventtodiscord/controller/SubscriptionControllerTests.java
+++ b/src/test/java/me/cocoblue/chzzkeventtodiscord/controller/SubscriptionControllerTests.java
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Transactional
 class SubscriptionControllerTests {
     private static final String OWNER_CHANNEL_ID = "owner-channel-1";
     private static final String OTHER_OWNER_CHANNEL_ID = "owner-channel-2";
@@ -69,9 +71,13 @@ class SubscriptionControllerTests {
         discordWebhookDataRepository.deleteAll();
         chzzkChannelRepository.deleteAll();
 
-        final ChzzkChannelEntity ownerChannel = createChannel(OWNER_CHANNEL_ID, "Owner One");
-        final ChzzkChannelEntity otherOwnerChannel = createChannel(OTHER_OWNER_CHANNEL_ID, "Owner Two");
-        final ChzzkChannelEntity targetChannel = createChannel(TARGET_CHANNEL_ID, "Target");
+        createChannel(OWNER_CHANNEL_ID, "Owner One");
+        createChannel(OTHER_OWNER_CHANNEL_ID, "Owner Two");
+        createChannel(TARGET_CHANNEL_ID, "Target");
+
+        final ChzzkChannelEntity ownerChannel = chzzkChannelRepository.getReferenceById(OWNER_CHANNEL_ID);
+        final ChzzkChannelEntity otherOwnerChannel = chzzkChannelRepository.getReferenceById(OTHER_OWNER_CHANNEL_ID);
+        final ChzzkChannelEntity targetChannel = chzzkChannelRepository.getReferenceById(TARGET_CHANNEL_ID);
 
         ownerWebhook = discordWebhookDataRepository.save(DiscordWebhookDataEntity.builder()
             .name("owner webhook")
@@ -219,7 +225,7 @@ class SubscriptionControllerTests {
     }
 
     private ChzzkChannelEntity createChannel(String channelId, String channelName) {
-        return chzzkChannelRepository.save(ChzzkChannelEntity.builder()
+        return chzzkChannelRepository.saveAndFlush(ChzzkChannelEntity.builder()
             .channelId(channelId)
             .channelName(channelName)
             .profileUrl("https://example.test/profile/" + channelId)

--- a/src/test/java/me/cocoblue/chzzkeventtodiscord/controller/SubscriptionControllerTests.java
+++ b/src/test/java/me/cocoblue/chzzkeventtodiscord/controller/SubscriptionControllerTests.java
@@ -1,0 +1,234 @@
+package me.cocoblue.chzzkeventtodiscord.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.cocoblue.chzzkeventtodiscord.data.LanguageIsoData;
+import me.cocoblue.chzzkeventtodiscord.data.chzzk.ChzzkSubscriptionType;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkChannelEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkChannelRepository;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkSubscriptionFormEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkSubscriptionFormRepository;
+import me.cocoblue.chzzkeventtodiscord.domain.discord.DiscordBotProfileDataEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.discord.DiscordBotProfileDataRepository;
+import me.cocoblue.chzzkeventtodiscord.domain.discord.DiscordWebhookDataEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.discord.DiscordWebhookDataRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SubscriptionControllerTests {
+    private static final String OWNER_CHANNEL_ID = "owner-channel-1";
+    private static final String OTHER_OWNER_CHANNEL_ID = "owner-channel-2";
+    private static final String TARGET_CHANNEL_ID = "target-channel";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private ChzzkChannelRepository chzzkChannelRepository;
+    @Autowired
+    private ChzzkSubscriptionFormRepository chzzkSubscriptionFormRepository;
+    @Autowired
+    private DiscordWebhookDataRepository discordWebhookDataRepository;
+    @Autowired
+    private DiscordBotProfileDataRepository discordBotProfileDataRepository;
+
+    private DiscordWebhookDataEntity ownerWebhook;
+    private DiscordBotProfileDataEntity ownerBotProfile;
+    private ChzzkSubscriptionFormEntity ownerSubscription;
+    private ChzzkSubscriptionFormEntity otherOwnerSubscription;
+
+    @BeforeEach
+    void setUp() {
+        chzzkSubscriptionFormRepository.deleteAll();
+        discordBotProfileDataRepository.deleteAll();
+        discordWebhookDataRepository.deleteAll();
+        chzzkChannelRepository.deleteAll();
+
+        final ChzzkChannelEntity ownerChannel = createChannel(OWNER_CHANNEL_ID, "Owner One");
+        final ChzzkChannelEntity otherOwnerChannel = createChannel(OTHER_OWNER_CHANNEL_ID, "Owner Two");
+        final ChzzkChannelEntity targetChannel = createChannel(TARGET_CHANNEL_ID, "Target");
+
+        ownerWebhook = discordWebhookDataRepository.save(DiscordWebhookDataEntity.builder()
+            .name("owner webhook")
+            .webhookUrl("https://example.test/webhook/owner")
+            .ownerId(ownerChannel)
+            .build());
+        ownerBotProfile = discordBotProfileDataRepository.save(DiscordBotProfileDataEntity.builder()
+            .ownerId(ownerChannel)
+            .username("owner bot")
+            .avatarUrl("https://example.test/avatar/owner")
+            .build());
+
+        final DiscordWebhookDataEntity otherWebhook = discordWebhookDataRepository.save(DiscordWebhookDataEntity.builder()
+            .name("other webhook")
+            .webhookUrl("https://example.test/webhook/other")
+            .ownerId(otherOwnerChannel)
+            .build());
+        final DiscordBotProfileDataEntity otherBotProfile = discordBotProfileDataRepository.save(DiscordBotProfileDataEntity.builder()
+            .ownerId(otherOwnerChannel)
+            .username("other bot")
+            .avatarUrl("https://example.test/avatar/other")
+            .build());
+
+        ownerSubscription = chzzkSubscriptionFormRepository.save(ChzzkSubscriptionFormEntity.builder()
+            .chzzkChannelEntity(targetChannel)
+            .formOwner(ownerChannel)
+            .chzzkSubscriptionType(ChzzkSubscriptionType.STREAM_OFFLINE)
+            .webhookId(ownerWebhook)
+            .botProfileId(ownerBotProfile)
+            .languageIsoData(LanguageIsoData.Korean)
+            .intervalMinute(10)
+            .enabled(true)
+            .colorHex("000000")
+            .content("owner content")
+            .build());
+
+        otherOwnerSubscription = chzzkSubscriptionFormRepository.save(ChzzkSubscriptionFormEntity.builder()
+            .chzzkChannelEntity(targetChannel)
+            .formOwner(otherOwnerChannel)
+            .chzzkSubscriptionType(ChzzkSubscriptionType.CHANNEL_UPDATE)
+            .webhookId(otherWebhook)
+            .botProfileId(otherBotProfile)
+            .languageIsoData(LanguageIsoData.English)
+            .intervalMinute(20)
+            .enabled(true)
+            .colorHex("123456")
+            .content("other content")
+            .build());
+    }
+
+    @Test
+    void listForUserReturnsOnlyOwnedSubscriptions() throws Exception {
+        mockMvc.perform(get("/api/v1/subscriptions")
+                .with(SecurityMockMvcRequestPostProcessors.user(OWNER_CHANNEL_ID).roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content", hasSize(1)))
+            .andExpect(jsonPath("$.content[0].id").value(ownerSubscription.getId()))
+            .andExpect(jsonPath("$.content[0].formOwnerChannelId").value(OWNER_CHANNEL_ID));
+    }
+
+    @Test
+    void userCannotReadOrModifyOtherOwnersSubscriptions() throws Exception {
+        final String updatePayload = objectMapper.writeValueAsString(Map.of("content", "new content"));
+
+        mockMvc.perform(get("/api/v1/subscriptions/{id}", otherOwnerSubscription.getId())
+                .with(SecurityMockMvcRequestPostProcessors.user(OWNER_CHANNEL_ID).roles("USER")))
+            .andExpect(status().isForbidden());
+
+        mockMvc.perform(put("/api/v1/subscriptions/{id}", otherOwnerSubscription.getId())
+                .with(SecurityMockMvcRequestPostProcessors.user(OWNER_CHANNEL_ID).roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload))
+            .andExpect(status().isForbidden());
+
+        mockMvc.perform(delete("/api/v1/subscriptions/{id}", otherOwnerSubscription.getId())
+                .with(SecurityMockMvcRequestPostProcessors.user(OWNER_CHANNEL_ID).roles("USER")))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void adminCanListAndReadAnySubscription() throws Exception {
+        mockMvc.perform(get("/api/v1/subscriptions")
+                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content", hasSize(2)));
+
+        mockMvc.perform(get("/api/v1/subscriptions/{id}", otherOwnerSubscription.getId())
+                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(otherOwnerSubscription.getId()))
+            .andExpect(jsonPath("$.formOwnerChannelId").value(OTHER_OWNER_CHANNEL_ID));
+    }
+
+    @Test
+    void userCanCreateUpdateAndDeleteOwnedSubscription() throws Exception {
+        final String createPayload = objectMapper.writeValueAsString(Map.of(
+            "channelId", TARGET_CHANNEL_ID,
+            "subscriptionType", "STREAM_OFFLINE",
+            "webhookId", ownerWebhook.getId(),
+            "botProfileId", ownerBotProfile.getId(),
+            "language", "Korean",
+            "intervalMinute", 15,
+            "enabled", true,
+            "content", "created content",
+            "colorHex", "ABCDEF"
+        ));
+
+        final String createResponseBody = mockMvc.perform(post("/api/v1/subscriptions")
+                .with(SecurityMockMvcRequestPostProcessors.user(OWNER_CHANNEL_ID).roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createPayload))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id", not(nullValue())))
+            .andExpect(jsonPath("$.formOwnerChannelId").value(OWNER_CHANNEL_ID))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        final Long createdId = objectMapper.readTree(createResponseBody).get("id").asLong();
+
+        final String updatePayload = objectMapper.writeValueAsString(Map.of(
+            "content", "updated content",
+            "enabled", false
+        ));
+
+        mockMvc.perform(put("/api/v1/subscriptions/{id}", createdId)
+                .with(SecurityMockMvcRequestPostProcessors.user(OWNER_CHANNEL_ID).roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").value("updated content"))
+            .andExpect(jsonPath("$.enabled").value(false));
+
+        mockMvc.perform(delete("/api/v1/subscriptions/{id}", createdId)
+                .with(SecurityMockMvcRequestPostProcessors.user(OWNER_CHANNEL_ID).roles("USER")))
+            .andExpect(status().isNoContent());
+
+        assertFalse(chzzkSubscriptionFormRepository.findById(createdId).isPresent());
+    }
+
+    @Test
+    void unauthenticatedRequestsAreRejected() throws Exception {
+        mockMvc.perform(get("/api/v1/subscriptions"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    private ChzzkChannelEntity createChannel(String channelId, String channelName) {
+        return chzzkChannelRepository.save(ChzzkChannelEntity.builder()
+            .channelId(channelId)
+            .channelName(channelName)
+            .profileUrl("https://example.test/profile/" + channelId)
+            .isVerifiedMark(false)
+            .channelDescription("desc-" + channelId)
+            .subscriptionAvailability(true)
+            .isLive(false)
+            .followerCount(0)
+            .lastCheckTime(ZonedDateTime.now(ZoneId.of("UTC")))
+            .build());
+    }
+}

--- a/src/test/java/me/cocoblue/chzzkeventtodiscord/security/SecurityConfigTests.java
+++ b/src/test/java/me/cocoblue/chzzkeventtodiscord/security/SecurityConfigTests.java
@@ -1,15 +1,19 @@
 package me.cocoblue.chzzkeventtodiscord.security;
 
+import me.cocoblue.chzzkeventtodiscord.service.ChzzkAuthService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -22,9 +26,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class SecurityConfigTests {
     @Autowired
     private MockMvc mockMvc;
+    @MockBean
+    private ChzzkAuthService chzzkAuthService;
 
     @Test
     void chzzkLoginEndpointIsPermitAll() throws Exception {
+        given(chzzkAuthService.buildAuthorizationUrl(anyString()))
+            .willAnswer(invocation -> "https://chzzk.naver.com/account-interlock?state=" + invocation.getArgument(0));
+
         mockMvc.perform(get("/api/v1/auth/chzzk/login"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.authorizationUrl").value(org.hamcrest.Matchers.containsString("account-interlock")))
@@ -33,11 +42,12 @@ class SecurityConfigTests {
 
     @Test
     void chzzkCallbackEndpointIsPermitAllAndCreatesAuthenticatedSession() throws Exception {
+        given(chzzkAuthService.authenticateFromCallback(anyString(), anyString()))
+            .willReturn(new ChzzkPrincipal("channel-123", AppRole.USER));
+
         MvcResult callbackResult = mockMvc.perform(get("/api/v1/auth/chzzk/callback")
                 .param("code", "mock-auth-code")
-                .param("state", "mock-state")
-                .param("mockChannelId", "channel-123")
-                .param("mockRole", "USER"))
+                .param("state", "mock-state"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.channelId").value("channel-123"))
             .andExpect(jsonPath("$.role").value("USER"))
@@ -78,11 +88,12 @@ class SecurityConfigTests {
 
     @Test
     void logoutReturnsOkForAuthenticatedSession() throws Exception {
+        given(chzzkAuthService.authenticateFromCallback(anyString(), anyString()))
+            .willReturn(new ChzzkPrincipal("channel-logout", AppRole.USER));
+
         MvcResult callbackResult = mockMvc.perform(get("/api/v1/auth/chzzk/callback")
                 .param("code", "mock-auth-code")
-                .param("state", "mock-state")
-                .param("mockChannelId", "channel-logout")
-                .param("mockRole", "USER"))
+                .param("state", "mock-state"))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -92,5 +103,11 @@ class SecurityConfigTests {
         mockMvc.perform(post("/api/v1/auth/logout").session(session))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.message").value("Logged out"));
+    }
+
+    @Test
+    void subscriptionsEndpointRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/subscriptions"))
+            .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/me/cocoblue/chzzkeventtodiscord/service/ChzzkAuthServiceTests.java
+++ b/src/test/java/me/cocoblue/chzzkeventtodiscord/service/ChzzkAuthServiceTests.java
@@ -1,0 +1,139 @@
+package me.cocoblue.chzzkeventtodiscord.service;
+
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkChannelEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkChannelRepository;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkOAuthTokenEntity;
+import me.cocoblue.chzzkeventtodiscord.domain.chzzk.ChzzkOAuthTokenRepository;
+import me.cocoblue.chzzkeventtodiscord.security.AppRole;
+import me.cocoblue.chzzkeventtodiscord.security.ChzzkPrincipal;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ChzzkAuthServiceTests {
+    private static final MockWebServer MOCK_WEB_SERVER = new MockWebServer();
+
+    static {
+        try {
+            MOCK_WEB_SERVER.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Autowired
+    private ChzzkAuthService chzzkAuthService;
+    @Autowired
+    private ChzzkOAuthTokenRepository chzzkOAuthTokenRepository;
+    @Autowired
+    private ChzzkChannelRepository chzzkChannelRepository;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("chzzk.oauth.token-base-url", () -> MOCK_WEB_SERVER.url("/").toString());
+        registry.add("chzzk.oauth.api-base-url", () -> MOCK_WEB_SERVER.url("/").toString());
+        registry.add("chzzk.oauth.auth-base-url", () -> "https://chzzk.naver.com");
+        registry.add("chzzk.oauth.client-id", () -> "test-client-id");
+        registry.add("chzzk.oauth.client-secret", () -> "test-client-secret");
+        registry.add("chzzk.oauth.redirect-uri", () -> "https://example.test/callback");
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        chzzkOAuthTokenRepository.deleteAll();
+        chzzkChannelRepository.deleteAll();
+        while (MOCK_WEB_SERVER.takeRequest(10, TimeUnit.MILLISECONDS) != null) {
+            // drain recorded requests left by previous tests
+        }
+    }
+
+    @AfterAll
+    static void shutdownServer() throws IOException {
+        MOCK_WEB_SERVER.shutdown();
+    }
+
+    @Test
+    void authenticateFromCallbackExchangesTokenAndMapsIdentity() throws Exception {
+        MOCK_WEB_SERVER.enqueue(new MockResponse()
+            .addHeader("Content-Type", "application/json")
+            .setBody("""
+                {
+                  "access_token": "access-token-123",
+                  "refresh_token": "refresh-token-123",
+                  "token_type": "Bearer",
+                  "scope": "user.read",
+                  "expires_in": 3600,
+                  "refresh_token_expires_in": 7200
+                }
+                """));
+        MOCK_WEB_SERVER.enqueue(new MockResponse()
+            .addHeader("Content-Type", "application/json")
+            .setBody("""
+                {
+                  "content": {
+                    "channelId": "channel-abc",
+                    "channelName": "Channel ABC"
+                  }
+                }
+                """));
+
+        final ChzzkPrincipal principal = chzzkAuthService.authenticateFromCallback("code-123", "state-123");
+
+        assertEquals("channel-abc", principal.channelId());
+        assertEquals(AppRole.USER, principal.role());
+
+        final ChzzkOAuthTokenEntity tokenEntity = chzzkOAuthTokenRepository.findById("channel-abc").orElseThrow();
+        assertEquals("access-token-123", tokenEntity.getAccessToken());
+        assertEquals("refresh-token-123", tokenEntity.getRefreshToken());
+        assertEquals("Bearer", tokenEntity.getTokenType());
+        assertEquals("user.read", tokenEntity.getScope());
+        assertNotNull(tokenEntity.getAccessTokenExpiresAt());
+        assertNotNull(tokenEntity.getRefreshTokenExpiresAt());
+
+        final ChzzkChannelEntity channelEntity = chzzkChannelRepository.findById("channel-abc").orElseThrow();
+        assertEquals("Channel ABC", channelEntity.getChannelName());
+
+        final RecordedRequest tokenRequest = MOCK_WEB_SERVER.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(tokenRequest);
+        assertEquals("POST", tokenRequest.getMethod());
+        assertEquals("/auth/v1/token", tokenRequest.getPath());
+        final String tokenBody = tokenRequest.getBody().readUtf8();
+        assertTrue(tokenBody.contains("grantType=authorization_code"));
+        assertTrue(tokenBody.contains("code=code-123"));
+        assertTrue(tokenBody.contains("state=state-123"));
+        assertTrue(tokenBody.contains("clientId=test-client-id"));
+
+        final RecordedRequest userMeRequest = MOCK_WEB_SERVER.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(userMeRequest);
+        assertEquals("GET", userMeRequest.getMethod());
+        assertEquals("/open/v1/users/me", userMeRequest.getPath());
+        assertEquals("Bearer access-token-123", userMeRequest.getHeader("Authorization"));
+    }
+
+    @Test
+    void buildAuthorizationUrlUsesConfiguredValues() {
+        final String authorizationUrl = chzzkAuthService.buildAuthorizationUrl("state-xyz");
+
+        assertTrue(authorizationUrl.startsWith("https://chzzk.naver.com/account-interlock"));
+        assertTrue(authorizationUrl.contains("clientId=test-client-id"));
+        assertTrue(authorizationUrl.contains("redirectUri="));
+        assertTrue(authorizationUrl.contains("state=state-xyz"));
+    }
+}


### PR DESCRIPTION
Summary:
- Add /api/v1/subscriptions CRUD with ownership enforcement (USER = own channelId; ADMIN = all)
- Implement real Chzzk OAuth callback: code -> token exchange -> /open/v1/users/me -> channelId mapping
- Persist OAuth tokens keyed by channelId (H2 in tests)
- Add MockWebServer-based tests (no external network)

Test:
- Ran: GRADLE_USER_HOME=/tmp/.gradle ./gradlew test --no-daemon (local)