### PR TITLE
feat(frontend): auth + subscriptions CRUD UI

### DIFF
--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,15 +1,13 @@
 import { expect, test } from '@playwright/test';
 
-test('guest access to protected app routes is blocked', async ({ page }) => {
-  await page.goto('/app/dashboard');
-  await expect(page).toHaveURL(/\/$/);
-  await expect(page.getByRole('heading', { name: 'Chzzk Event to Discord' })).toBeVisible();
+test('guest access to protected subscriptions routes is blocked', async ({ page }) => {
+  await page.goto('/subscriptions');
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole('heading', { name: 'Login' })).toBeVisible();
 });
 
-test('mock oauth callback can open authenticated dashboard', async ({ page }) => {
-  await page.goto('/auth/chzzk/login');
-  await page.getByRole('button', { name: 'Simulate USER callback' }).click();
-  await page.getByRole('button', { name: 'Complete sign in' }).click();
-  await expect(page).toHaveURL(/\/app\/dashboard$/);
-  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+test('login route is accessible for users', async ({ page }) => {
+  await page.goto('/login');
+  await expect(page.getByRole('heading', { name: 'Login' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Login with Chzzk' })).toBeVisible();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,11 @@
 import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
+import { AuthProvider } from './auth/AuthContext';
 
 export default function App() {
-  return <RouterProvider router={router} />;
+  return (
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
+  );
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,6 +17,9 @@ function buildApiUrl(path: string): string {
   return `${env.apiBaseUrl}${normalizedPath}`;
 }
 
+type JsonBody = string | number | boolean | null | JsonBody[] | { [key: string]: JsonBody };
+type RequestOptions<B = JsonBody> = Omit<RequestInit, 'body'> & { body?: B };
+
 function isJsonResponse(response: Response): boolean {
   return (response.headers.get('content-type') ?? '').includes('application/json');
 }
@@ -53,7 +56,7 @@ function extractErrorMessage(body: unknown, fallback: string): string {
   return fallback;
 }
 
-async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+async function request<T, B = JsonBody>(path: string, init: RequestOptions<B> = {}): Promise<T> {
   const method = init.method ?? 'GET';
   const headers = new Headers(init.headers ?? {});
   headers.set('Accept', 'application/json');
@@ -80,14 +83,14 @@ export async function apiGet<T>(path: string): Promise<T> {
   return request<T>(path, { method: 'GET' });
 }
 
-export async function apiPost<T, B = unknown>(path: string, body?: B): Promise<T> {
+export async function apiPost<T, B extends JsonBody = JsonBody>(path: string, body?: B): Promise<T> {
   return request<T>(path, {
     method: 'POST',
     body,
   });
 }
 
-export async function apiPut<T, B = unknown>(path: string, body: B): Promise<T> {
+export async function apiPut<T, B extends JsonBody = JsonBody>(path: string, body: B): Promise<T> {
   return request<T>(path, {
     method: 'PUT',
     body,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,23 +1,99 @@
 import { env } from '../config/env';
 
+export class ApiError extends Error {
+  status: number;
+  body?: unknown;
+
+  constructor(status: number, message: string, body?: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
 function buildApiUrl(path: string): string {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
   return `${env.apiBaseUrl}${normalizedPath}`;
 }
 
-export async function apiGet<T>(path: string): Promise<T> {
-  const response = await fetch(buildApiUrl(path), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json',
-    },
-    credentials: 'include',
-  });
+function isJsonResponse(response: Response): boolean {
+  return (response.headers.get('content-type') ?? '').includes('application/json');
+}
 
-  if (!response.ok) {
-    const text = await response.text().catch(() => '');
-    throw new Error(`API request failed with status ${response.status}: ${text}`);
+async function parseResponseBody(response: Response): Promise<unknown | null> {
+  const text = await response.text().catch(() => '');
+  if (!text) {
+    return null;
   }
 
-  return (await response.json()) as T;
+  if (!isJsonResponse(response)) {
+    return text;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function extractErrorMessage(body: unknown, fallback: string): string {
+  if (typeof body === 'string' && body.trim().length > 0) {
+    return body.trim();
+  }
+
+  if (body && typeof body === 'object') {
+    const value = (body as { message?: unknown }).message;
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  return fallback;
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const method = init.method ?? 'GET';
+  const headers = new Headers(init.headers ?? {});
+  headers.set('Accept', 'application/json');
+
+  const response = await fetch(buildApiUrl(path), {
+    ...init,
+    method,
+    headers,
+    credentials: 'include',
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+
+  const body = await parseResponseBody(response);
+
+  if (!response.ok) {
+    const message = extractErrorMessage(body, `Request failed with status ${response.status}`);
+    throw new ApiError(response.status, message, body);
+  }
+
+  return body as T;
+}
+
+export async function apiGet<T>(path: string): Promise<T> {
+  return request<T>(path, { method: 'GET' });
+}
+
+export async function apiPost<T, B = unknown>(path: string, body?: B): Promise<T> {
+  return request<T>(path, {
+    method: 'POST',
+    body,
+  });
+}
+
+export async function apiPut<T, B = unknown>(path: string, body: B): Promise<T> {
+  return request<T>(path, {
+    method: 'PUT',
+    body,
+  });
+}
+
+export async function apiDelete<T = void>(path: string): Promise<T> {
+  return request<T>(path, { method: 'DELETE' });
 }

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,0 +1,72 @@
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { ApiError, apiGet, apiPost } from '../api/client';
+import { AppSession, clearSession, setSession } from './session';
+
+type AuthContextValue = {
+  session: AppSession | null;
+  loading: boolean;
+  reloadSession: () => Promise<void>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSessionState] = useState<AppSession | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const reloadSession = useCallback(async () => {
+    setLoading(true);
+    try {
+      const nextSession = await apiGet<AppSession>('/auth/me');
+      setSessionState(nextSession);
+      setSession(nextSession);
+      return;
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        setSessionState(null);
+        clearSession();
+      } else {
+        setSessionState(null);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reloadSession();
+  }, [reloadSession]);
+
+  const logout = useCallback(async () => {
+    try {
+      await apiPost('/auth/logout');
+    } catch (error) {
+      // Keep client-side sign-out even if server-side logout fails.
+      console.error(error);
+    } finally {
+      setSessionState(null);
+      clearSession();
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      session,
+      loading,
+      reloadSession,
+      logout,
+    }),
+    [session, loading, reloadSession, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used inside AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/auth/RouteGuards.tsx
+++ b/frontend/src/auth/RouteGuards.tsx
@@ -1,26 +1,34 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { getSession } from './session';
+import { useAuth } from './AuthContext';
 
 export function RequireAuth() {
-  const session = getSession();
+  const { session, loading } = useAuth();
   const location = useLocation();
 
+  if (loading) {
+    return <div className="text-center py-5">Checking session...</div>;
+  }
+
   if (!session) {
-    return <Navigate to="/" replace state={{ from: location.pathname }} />;
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
   }
 
   return <Outlet />;
 }
 
 export function RequireAdmin() {
-  const session = getSession();
+  const { session, loading } = useAuth();
+
+  if (loading) {
+    return <div className="text-center py-5">Checking session...</div>;
+  }
 
   if (!session) {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/login" replace />;
   }
 
   if (session.role !== 'ADMIN') {
-    return <Navigate to="/app/dashboard" replace />;
+    return <Navigate to="/subscriptions" replace />;
   }
 
   return <Outlet />;

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -1,17 +1,26 @@
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
-import { clearSession, getSession } from '../auth/session';
+import { useAuth } from '../auth/AuthContext';
 
 function navLinkClass({ isActive }: { isActive: boolean }) {
   return `nav-link${isActive ? ' active fw-semibold' : ''}`;
 }
 
+function formatChannelLabel(channelId: string): string {
+  const truncated = channelId.trim();
+  if (truncated.length <= 20) {
+    return truncated;
+  }
+  return `${truncated.slice(0, 20)}…`;
+}
+
+
 export function MainLayout() {
   const navigate = useNavigate();
-  const session = getSession();
+  const { session, logout } = useAuth();
 
-  function handleLogout() {
-    clearSession();
-    navigate('/');
+  async function handleLogout() {
+    await logout();
+    navigate('/login');
   }
 
   return (
@@ -36,31 +45,22 @@ export function MainLayout() {
           <div className="collapse navbar-collapse" id="mainNav">
             <ul className="navbar-nav me-auto mb-2 mb-lg-0">
               <li className="nav-item">
-                <NavLink to="/app/dashboard" className={navLinkClass}>
-                  Dashboard
-                </NavLink>
-              </li>
-              <li className="nav-item">
-                <NavLink to="/app/subscriptions" className={navLinkClass}>
+                <NavLink to="/subscriptions" className={navLinkClass}>
                   Subscriptions
-                </NavLink>
-              </li>
-              <li className="nav-item">
-                <NavLink to="/admin/users" className={navLinkClass}>
-                  Admin
                 </NavLink>
               </li>
             </ul>
             <div className="d-flex align-items-center gap-2">
               {session ? (
                 <>
-                  <span className="badge text-bg-secondary">{session.role}</span>
+                  <span className="badge text-bg-secondary text-uppercase">{session.role}</span>
+                  <span className="text-light small">Channel: {formatChannelLabel(session.channelId)}</span>
                   <button type="button" onClick={handleLogout} className="btn btn-outline-light btn-sm">
                     Logout
                   </button>
                 </>
               ) : (
-                <NavLink to="/auth/chzzk/login" className="btn btn-outline-light btn-sm">
+                <NavLink to="/login" className="btn btn-outline-light btn-sm">
                   Login with Chzzk
                 </NavLink>
               )}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -6,15 +6,14 @@ export function LandingPage() {
       <div className="container-fluid py-2">
         <h1 className="display-6 fw-bold">Chzzk Event to Discord</h1>
         <p className="col-md-9 fs-5 text-secondary">
-          Public landing page scaffold. Use this entry point to begin Chzzk OAuth and navigate to app/admin
-          sections.
+          Chzzk Event to Discord now exposes authenticated subscription management under <code>/subscriptions</code>.
         </p>
         <div className="d-flex flex-wrap gap-2">
-          <Link to="/auth/chzzk/login" className="btn btn-primary">
+          <Link to="/login" className="btn btn-primary">
             Login with Chzzk
           </Link>
-          <Link to="/app/dashboard" className="btn btn-outline-secondary">
-            Go to Dashboard
+          <Link to="/subscriptions" className="btn btn-outline-secondary">
+            Go to Subscriptions
           </Link>
         </div>
       </div>

--- a/frontend/src/pages/app/NewSubscriptionPage.tsx
+++ b/frontend/src/pages/app/NewSubscriptionPage.tsx
@@ -1,7 +1,196 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ApiError, apiPost } from '../../api/client';
 import { PagePlaceholder } from '../../components/PagePlaceholder';
 
+type SubscriptionType = 'STREAM_ONLINE' | 'STREAM_OFFLINE' | 'CHANNEL_UPDATE' | 'STREAM_ONLINE_AND_OFFLINE';
+
+type FormState = {
+  channelId: string;
+  subscriptionType: SubscriptionType;
+  webhookId: string;
+  botProfileId: string;
+  intervalMinute: string;
+  enabled: boolean;
+  content: string;
+};
+
+type ApiPayload = {
+  channelId: string;
+  subscriptionType: SubscriptionType;
+  webhookId: number;
+  botProfileId: number;
+  intervalMinute: number;
+  enabled: boolean;
+  content: string;
+};
+
+function createInitialState(): FormState {
+  return {
+    channelId: '',
+    subscriptionType: 'STREAM_ONLINE',
+    webhookId: '',
+    botProfileId: '',
+    intervalMinute: '10',
+    enabled: true,
+    content: '',
+  };
+}
+
 export function NewSubscriptionPage() {
+  const navigate = useNavigate();
+  const [formState, setFormState] = useState<FormState>(createInitialState);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const formIsValid = useMemo(() => {
+    return Boolean(formState.channelId.trim() && formState.webhookId.trim() && formState.botProfileId.trim());
+  }, [formState]);
+
+  function updateField(name: keyof FormState, value: string | boolean) {
+    setFormState((current) => ({ ...current, [name]: value }));
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setLoading(true);
+    setError('');
+
+    const webhookId = Number(formState.webhookId);
+    const botProfileId = Number(formState.botProfileId);
+    const intervalMinute = Number(formState.intervalMinute);
+
+    if (!formIsValid || !Number.isFinite(webhookId) || !Number.isFinite(botProfileId) || !Number.isFinite(intervalMinute)) {
+      setError('Please fill required fields with valid numeric values.');
+      setLoading(false);
+      return;
+    }
+
+    const payload: ApiPayload = {
+      channelId: formState.channelId.trim(),
+      subscriptionType: formState.subscriptionType,
+      webhookId,
+      botProfileId,
+      intervalMinute,
+      enabled: formState.enabled,
+      content: formState.content,
+    };
+
+    try {
+      await apiPost('/subscriptions', payload);
+      navigate('/subscriptions');
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : 'Unable to create subscription.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
-    <PagePlaceholder title="New Subscription" description="Subscription creation form placeholder." />
+    <PagePlaceholder title="New Subscription" description="Create a new subscription configuration.">
+      {error ? <div className="alert alert-danger">{error}</div> : null}
+      <form className="row g-3 mt-1" onSubmit={handleSubmit}>
+        <div className="col-12">
+          <label htmlFor="channelId" className="form-label">
+            Channel ID (target channel)
+          </label>
+          <input
+            id="channelId"
+            className="form-control"
+            value={formState.channelId}
+            onChange={(event) => updateField('channelId', event.target.value)}
+            required
+          />
+        </div>
+        <div className="col-12">
+          <label htmlFor="subscriptionType" className="form-label">
+            Subscription type
+          </label>
+          <select
+            id="subscriptionType"
+            className="form-select"
+            value={formState.subscriptionType}
+            onChange={(event) => updateField('subscriptionType', event.target.value as SubscriptionType)}
+            required
+          >
+            <option value="STREAM_ONLINE">STREAM_ONLINE</option>
+            <option value="STREAM_OFFLINE">STREAM_OFFLINE</option>
+            <option value="CHANNEL_UPDATE">CHANNEL_UPDATE</option>
+            <option value="STREAM_ONLINE_AND_OFFLINE">STREAM_ONLINE_AND_OFFLINE</option>
+          </select>
+        </div>
+        <div className="col-md-6">
+          <label htmlFor="webhookId" className="form-label">
+            Webhook ID
+          </label>
+          <input
+            id="webhookId"
+            className="form-control"
+            inputMode="numeric"
+            value={formState.webhookId}
+            onChange={(event) => updateField('webhookId', event.target.value)}
+            required
+          />
+        </div>
+        <div className="col-md-6">
+          <label htmlFor="botProfileId" className="form-label">
+            Bot Profile ID
+          </label>
+          <input
+            id="botProfileId"
+            className="form-control"
+            inputMode="numeric"
+            value={formState.botProfileId}
+            onChange={(event) => updateField('botProfileId', event.target.value)}
+            required
+          />
+        </div>
+        <div className="col-md-4">
+          <label htmlFor="intervalMinute" className="form-label">
+            Interval (minutes)
+          </label>
+          <input
+            id="intervalMinute"
+            className="form-control"
+            inputMode="numeric"
+            value={formState.intervalMinute}
+            onChange={(event) => updateField('intervalMinute', event.target.value)}
+            required
+          />
+        </div>
+        <div className="col-md-4 d-flex align-items-end">
+          <div className="form-check">
+            <input
+              id="enabled"
+              className="form-check-input"
+              type="checkbox"
+              checked={formState.enabled}
+              onChange={(event) => updateField('enabled', event.target.checked)}
+            />
+            <label className="form-check-label" htmlFor="enabled">
+              Enabled
+            </label>
+          </div>
+        </div>
+        <div className="col-12">
+          <label htmlFor="content" className="form-label">
+            Content
+          </label>
+          <textarea
+            id="content"
+            className="form-control"
+            value={formState.content}
+            onChange={(event) => updateField('content', event.target.value)}
+            rows={3}
+          />
+        </div>
+        <div className="col-12">
+          <button type="submit" className="btn btn-primary" disabled={loading || !formIsValid}>
+            {loading ? 'Creating...' : 'Create subscription'}
+          </button>
+        </div>
+      </form>
+    </PagePlaceholder>
   );
 }

--- a/frontend/src/pages/app/SubscriptionDetailPage.tsx
+++ b/frontend/src/pages/app/SubscriptionDetailPage.tsx
@@ -1,13 +1,249 @@
-import { useParams } from 'react-router-dom';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ApiError, apiDelete, apiGet, apiPut } from '../../api/client';
 import { PagePlaceholder } from '../../components/PagePlaceholder';
+
+type SubscriptionType = 'STREAM_ONLINE' | 'STREAM_OFFLINE' | 'CHANNEL_UPDATE' | 'STREAM_ONLINE_AND_OFFLINE';
+
+type SubscriptionPayload = {
+  channelId: string;
+  subscriptionType: SubscriptionType;
+  webhookId: number;
+  botProfileId: number;
+  intervalMinute: number;
+  enabled: boolean;
+  content: string;
+};
+
+type FormState = {
+  channelId: string;
+  subscriptionType: SubscriptionType;
+  webhookId: string;
+  botProfileId: string;
+  intervalMinute: string;
+  enabled: boolean;
+  content: string;
+};
+
+const emptyForm: FormState = {
+  channelId: '',
+  subscriptionType: 'STREAM_ONLINE',
+  webhookId: '',
+  botProfileId: '',
+  intervalMinute: '10',
+  enabled: true,
+  content: '',
+};
 
 export function SubscriptionDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [formState, setFormState] = useState<FormState>(emptyForm);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const canSubmit = useMemo(() => {
+    return Boolean(formState.channelId.trim() && formState.webhookId.trim() && formState.botProfileId.trim());
+  }, [formState]);
+
+  useEffect(() => {
+    if (!id) {
+      setError('Missing subscription id.');
+      setLoading(false);
+      return;
+    }
+
+    async function loadSubscription() {
+      try {
+        const response = await apiGet<SubscriptionPayload>(`/subscriptions/${id}`);
+        setFormState({
+          channelId: response.channelId,
+          subscriptionType: response.subscriptionType as SubscriptionType,
+          webhookId: String(response.webhookId),
+          botProfileId: String(response.botProfileId),
+          intervalMinute: String(response.intervalMinute ?? 10),
+          enabled: response.enabled,
+          content: response.content ?? '',
+        });
+      } catch (err) {
+        const message = err instanceof ApiError ? err.message : 'Unable to load subscription.';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    void loadSubscription();
+  }, [id]);
+
+  function updateField(name: keyof FormState, value: string | boolean) {
+    setFormState((current) => ({ ...current, [name]: value }));
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (!id || !canSubmit) {
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    const webhookId = Number(formState.webhookId);
+    const botProfileId = Number(formState.botProfileId);
+    const intervalMinute = Number(formState.intervalMinute);
+
+    if (!Number.isFinite(webhookId) || !Number.isFinite(botProfileId) || !Number.isFinite(intervalMinute)) {
+      setError('Please enter valid numeric values.');
+      setSaving(false);
+      return;
+    }
+
+    const payload: SubscriptionPayload = {
+      channelId: formState.channelId.trim(),
+      subscriptionType: formState.subscriptionType,
+      webhookId,
+      botProfileId,
+      intervalMinute,
+      enabled: formState.enabled,
+      content: formState.content,
+    };
+
+    try {
+      await apiPut(`/subscriptions/${id}`, payload);
+      navigate('/subscriptions');
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : 'Unable to update subscription.';
+      setError(message);
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!id || !window.confirm('Delete this subscription?')) {
+      return;
+    }
+
+    try {
+      await apiDelete(`/subscriptions/${id}`);
+      navigate('/subscriptions');
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : 'Unable to delete subscription.';
+      setError(message);
+    }
+  }
+
+  if (loading) {
+    return <div className="py-5 text-center">Loading subscription...</div>;
+  }
 
   return (
-    <PagePlaceholder
-      title="Subscription Detail"
-      description={`Subscription detail placeholder for id: ${id ?? 'unknown'}.`}
-    />
+    <PagePlaceholder title={`Edit subscription ${id ?? ''}`} description="Update an existing subscription configuration.">
+      {error ? <div className="alert alert-danger">{error}</div> : null}
+      <form className="row g-3 mt-1" onSubmit={handleSubmit}>
+        <div className="col-12">
+          <label htmlFor="channelId" className="form-label">
+            Channel ID (target channel)
+          </label>
+          <input
+            id="channelId"
+            className="form-control"
+            value={formState.channelId}
+            onChange={(event) => updateField('channelId', event.target.value)}
+            required
+          />
+        </div>
+        <div className="col-12">
+          <label htmlFor="subscriptionType" className="form-label">
+            Subscription type
+          </label>
+          <select
+            id="subscriptionType"
+            className="form-select"
+            value={formState.subscriptionType}
+            onChange={(event) => updateField('subscriptionType', event.target.value as SubscriptionType)}
+            required
+          >
+            <option value="STREAM_ONLINE">STREAM_ONLINE</option>
+            <option value="STREAM_OFFLINE">STREAM_OFFLINE</option>
+            <option value="CHANNEL_UPDATE">CHANNEL_UPDATE</option>
+            <option value="STREAM_ONLINE_AND_OFFLINE">STREAM_ONLINE_AND_OFFLINE</option>
+          </select>
+        </div>
+        <div className="col-md-6">
+          <label htmlFor="webhookId" className="form-label">
+            Webhook ID
+          </label>
+          <input
+            id="webhookId"
+            className="form-control"
+            inputMode="numeric"
+            value={formState.webhookId}
+            onChange={(event) => updateField('webhookId', event.target.value)}
+            required
+          />
+        </div>
+        <div className="col-md-6">
+          <label htmlFor="botProfileId" className="form-label">
+            Bot Profile ID
+          </label>
+          <input
+            id="botProfileId"
+            className="form-control"
+            inputMode="numeric"
+            value={formState.botProfileId}
+            onChange={(event) => updateField('botProfileId', event.target.value)}
+            required
+          />
+        </div>
+        <div className="col-md-4">
+          <label htmlFor="intervalMinute" className="form-label">
+            Interval (minutes)
+          </label>
+          <input
+            id="intervalMinute"
+            className="form-control"
+            inputMode="numeric"
+            value={formState.intervalMinute}
+            onChange={(event) => updateField('intervalMinute', event.target.value)}
+            required
+          />
+        </div>
+        <div className="col-md-4 d-flex align-items-end">
+          <div className="form-check">
+            <input
+              id="enabled"
+              className="form-check-input"
+              type="checkbox"
+              checked={formState.enabled}
+              onChange={(event) => updateField('enabled', event.target.checked)}
+            />
+            <label className="form-check-label" htmlFor="enabled">
+              Enabled
+            </label>
+          </div>
+        </div>
+        <div className="col-12">
+          <label htmlFor="content" className="form-label">
+            Content
+          </label>
+          <textarea
+            id="content"
+            className="form-control"
+            value={formState.content}
+            onChange={(event) => updateField('content', event.target.value)}
+            rows={3}
+          />
+        </div>
+        <div className="col-12 d-flex gap-2">
+          <button type="submit" className="btn btn-primary" disabled={saving || !canSubmit}>
+            {saving ? 'Saving...' : 'Save changes'}
+          </button>
+          <button type="button" className="btn btn-outline-danger" onClick={() => void handleDelete()}>
+            Delete
+          </button>
+        </div>
+      </form>
+    </PagePlaceholder>
   );
 }

--- a/frontend/src/pages/app/SubscriptionsPage.tsx
+++ b/frontend/src/pages/app/SubscriptionsPage.tsx
@@ -1,10 +1,242 @@
+import { Link, useSearchParams } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ApiError, apiDelete, apiGet } from '../../api/client';
 import { PagePlaceholder } from '../../components/PagePlaceholder';
 
+type SortKey = 'id,desc' | 'id,asc' | 'createdAt,desc' | 'createdAt,asc';
+type SortOptions = { value: SortKey; label: string }[];
+
+type SubscriptionItem = {
+  id: number;
+  channelId: string;
+  subscriptionType: string;
+  enabled: boolean;
+  webhookId: number;
+  botProfileId: number;
+  intervalMinute: number;
+  createdAt: string;
+};
+
+type SubscriptionPage = {
+  content: SubscriptionItem[];
+  number: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  first: boolean;
+  last: boolean;
+};
+
+const sortOptions: SortOptions = [
+  { value: 'id,desc', label: 'ID (newest)' },
+  { value: 'id,asc', label: 'ID (oldest)' },
+  { value: 'createdAt,desc', label: 'Created at (newest)' },
+  { value: 'createdAt,asc', label: 'Created at (oldest)' },
+];
+
+function parsePageNumber(value: string | null, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function parsePageSize(value: string | null, fallback: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.min(100, Math.max(1, parsed));
+}
+
+function parseSort(value: string | null): SortKey {
+  const next = sortOptions.some((option) => option.value === value) ? value : null;
+  return (next ?? 'id,desc') as SortKey;
+}
+
 export function SubscriptionsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const page = parsePageNumber(searchParams.get('page'), 0);
+  const size = parsePageSize(searchParams.get('size'), 10);
+  const sort = parseSort(searchParams.get('sort'));
+  const [subscriptions, setSubscriptions] = useState<SubscriptionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [pageState, setPageState] = useState({
+    totalPages: 1,
+    totalElements: 0,
+    first: true,
+    last: true,
+  });
+
+  const query = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set('page', String(page));
+    params.set('size', String(size));
+    params.set('sort', sort);
+    return params.toString();
+  }, [page, size, sort]);
+
+  const loadSubscriptions = useCallback(async () => {
+    setLoading(true);
+    setError('');
+
+    try {
+      const response = await apiGet<SubscriptionPage>(`/subscriptions?${query}`);
+      setSubscriptions(response.content ?? []);
+      setPageState({
+        totalPages: response.totalPages ?? 1,
+        totalElements: response.totalElements ?? 0,
+        first: response.first ?? page === 0,
+        last: response.last ?? response.number + 1 >= (response.totalPages ?? 1),
+      });
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : 'Failed to load subscriptions.';
+      setError(message);
+      setSubscriptions([]);
+      setPageState({ totalPages: 1, totalElements: 0, first: true, last: true });
+    } finally {
+      setLoading(false);
+    }
+  }, [query, page, size]);
+
+  useEffect(() => {
+    void loadSubscriptions();
+  }, [loadSubscriptions]);
+
+  const updateQuery = (next: Partial<{ page: number; size: number; sort: SortKey }>) => {
+    const params = new URLSearchParams(searchParams);
+    if (next.page !== undefined) {
+      params.set('page', String(next.page));
+    }
+    if (next.size !== undefined) {
+      params.set('size', String(next.size));
+    }
+    if (next.sort !== undefined) {
+      params.set('sort', next.sort);
+    }
+    setSearchParams(params);
+  };
+
+  const handleDelete = async (subscriptionId: number) => {
+    if (!window.confirm('Delete this subscription?')) {
+      return;
+    }
+
+    try {
+      await apiDelete(`/subscriptions/${subscriptionId}`);
+      await loadSubscriptions();
+    } catch {
+      setError('Failed to delete subscription.');
+    }
+  };
+
   return (
-    <PagePlaceholder
-      title="Subscriptions"
-      description="Subscriptions list placeholder. Query string state (search/filter/paging) can live in this URL."
-    />
+    <PagePlaceholder title="Subscriptions" description="Manage your notification subscriptions.">
+      {error ? <div className="alert alert-danger">{error}</div> : null}
+      <div className="d-flex flex-wrap gap-2 align-items-center mb-3">
+        <label className="form-label mb-0 small text-secondary d-flex align-items-center gap-2">
+          Sort
+          <select
+            className="form-select form-select-sm"
+            value={sort}
+            onChange={(event) => updateQuery({ page: 0, sort: event.target.value as SortKey })}
+          >
+            {sortOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="form-label mb-0 small text-secondary d-flex align-items-center gap-2">
+          Size
+          <select
+            className="form-select form-select-sm"
+            value={size}
+            onChange={(event) => updateQuery({ page: 0, size: Number(event.target.value) })}
+          >
+            {[5, 10, 20, 50].map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+        </label>
+        <span className="small text-secondary ms-auto">{pageState.totalElements} item(s)</span>
+      </div>
+
+      {loading ? (
+        <div className="text-center py-4">Loading…</div>
+      ) : (
+        <div className="table-responsive">
+          <table className="table table-hover align-middle">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Channel</th>
+                <th>Type</th>
+                <th>Enabled</th>
+                <th>Webhook</th>
+                <th>Bot Profile</th>
+                <th>Interval</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {subscriptions.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="text-center text-secondary">
+                    No subscriptions found.
+                  </td>
+                </tr>
+              ) : (
+                subscriptions.map((subscription) => (
+                  <tr key={subscription.id}>
+                    <td>{subscription.id}</td>
+                    <td>{subscription.channelId}</td>
+                    <td>
+                      <code>{subscription.subscriptionType}</code>
+                    </td>
+                    <td>{subscription.enabled ? 'Yes' : 'No'}</td>
+                    <td>{subscription.webhookId}</td>
+                    <td>{subscription.botProfileId}</td>
+                    <td>{subscription.intervalMinute}</td>
+                    <td className="d-flex gap-2">
+                      <Link className="btn btn-sm btn-outline-primary" to={`/subscriptions/${subscription.id}`}>
+                        Edit
+                      </Link>
+                      <button type="button" className="btn btn-sm btn-outline-danger" onClick={() => void handleDelete(subscription.id)}>
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="d-flex justify-content-between align-items-center">
+        <button
+          type="button"
+          className="btn btn-outline-secondary"
+          onClick={() => updateQuery({ page: Math.max(0, page - 1) })}
+          disabled={loading || pageState.first}
+        >
+          Previous
+        </button>
+        <span className="small text-secondary">
+          Page {page + 1} / {Math.max(pageState.totalPages, 1)}
+        </span>
+        <button
+          type="button"
+          className="btn btn-outline-secondary"
+          onClick={() => updateQuery({ page: page + 1 })}
+          disabled={loading || pageState.last}
+        >
+          Next
+        </button>
+      </div>
+    </PagePlaceholder>
   );
 }

--- a/frontend/src/pages/auth/ChzzkCallbackPage.tsx
+++ b/frontend/src/pages/auth/ChzzkCallbackPage.tsx
@@ -15,12 +15,12 @@ export function ChzzkCallbackPage() {
   const mockRole = parseMockRole(searchParams.get('mockRole'));
 
   function handleCompleteSignIn() {
-    if (!mockRole) {
-      return;
+      if (!mockRole) {
+        return;
+      }
+      setMockSession(mockRole);
+      navigate('/subscriptions');
     }
-    setMockSession(mockRole);
-    navigate('/app/dashboard');
-  }
 
   return (
     <PagePlaceholder

--- a/frontend/src/pages/auth/ChzzkLoginPage.tsx
+++ b/frontend/src/pages/auth/ChzzkLoginPage.tsx
@@ -1,25 +1,60 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { env } from '../../config/env';
 import { PagePlaceholder } from '../../components/PagePlaceholder';
+import { useAuth } from '../../auth/AuthContext';
+import { apiGet, ApiError } from '../../api/client';
 
 export function ChzzkLoginPage() {
-  const backendLoginUrl = `${env.apiBaseUrl}/auth/chzzk/login`;
+  const { session, loading, reloadSession } = useAuth();
+  const [isSubmitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  if (session) {
+    return (
+      <PagePlaceholder title="Already logged in" description="You are already authenticated.">
+        <div className="d-flex flex-wrap gap-2">
+          <button type="button" className="btn btn-outline-secondary" onClick={() => void reloadSession()}>
+            Refresh session
+          </button>
+          <Link className="btn btn-primary" to="/subscriptions">
+            Go to subscriptions
+          </Link>
+        </div>
+      </PagePlaceholder>
+    );
+  }
+
+  if (loading) {
+    return <div className="text-center py-5">Checking authentication state...</div>;
+  }
+
+  async function handleStartLogin() {
+    setSubmitting(true);
+    setError('');
+
+    try {
+      const response = await apiGet<{ authorizationUrl: string }>('/auth/chzzk/login');
+      window.location.href = response.authorizationUrl;
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : 'Unable to start login.';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
 
   return (
-    <PagePlaceholder
-      title="Chzzk Login"
-      description="This route will trigger backend OAuth start at /api/v1/auth/chzzk/login."
-    >
+    <PagePlaceholder title="Login" description="Sign in with Chzzk to continue.">
+      {error ? <div className="alert alert-danger">{error}</div> : null}
       <div className="d-flex flex-wrap gap-2">
-        <a className="btn btn-primary" href={backendLoginUrl}>
-          Login with Chzzk (Backend)
-        </a>
-        <Link className="btn btn-outline-secondary" to="/auth/chzzk/callback?mockRole=USER">
-          Simulate USER callback
-        </Link>
-        <Link className="btn btn-outline-secondary" to="/auth/chzzk/callback?mockRole=ADMIN">
-          Simulate ADMIN callback
-        </Link>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => void handleStartLogin()}
+          disabled={isSubmitting}
+        >
+          Login with Chzzk
+        </button>
       </div>
     </PagePlaceholder>
   );

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,32 +1,17 @@
 import { Navigate, createBrowserRouter } from 'react-router-dom';
-import { RequireAdmin, RequireAuth } from './auth/RouteGuards';
+import { RequireAuth } from './auth/RouteGuards';
 import { MainLayout } from './layouts/MainLayout';
 import { SectionLayout } from './layouts/SectionLayout';
-import { AdminAuditLogsPage } from './pages/admin/AdminAuditLogsPage';
-import { AdminSubscriptionsPage } from './pages/admin/AdminSubscriptionsPage';
-import { AdminUserDetailPage } from './pages/admin/AdminUserDetailPage';
-import { AdminUsersPage } from './pages/admin/AdminUsersPage';
-import { AccountSettingsPage } from './pages/app/AccountSettingsPage';
-import { DashboardPage } from './pages/app/DashboardPage';
 import { NewSubscriptionPage } from './pages/app/NewSubscriptionPage';
 import { SubscriptionDetailPage } from './pages/app/SubscriptionDetailPage';
 import { SubscriptionsPage } from './pages/app/SubscriptionsPage';
-import { ChzzkCallbackPage } from './pages/auth/ChzzkCallbackPage';
 import { ChzzkLoginPage } from './pages/auth/ChzzkLoginPage';
 import { LandingPage } from './pages/LandingPage';
 import { NotFoundPage } from './pages/NotFoundPage';
 
-const appNavItems = [
-  { to: '/app/dashboard', label: 'Dashboard' },
-  { to: '/app/subscriptions', label: 'Subscriptions' },
-  { to: '/app/subscriptions/new', label: 'New Subscription' },
-  { to: '/app/settings/account', label: 'Account Settings' },
-];
-
-const adminNavItems = [
-  { to: '/admin/users', label: 'Users' },
-  { to: '/admin/subscriptions', label: 'Subscriptions' },
-  { to: '/admin/audit-logs', label: 'Audit Logs' },
+const subscriptionNavItems = [
+  { to: '/subscriptions', label: 'Subscriptions' },
+  { to: '/subscriptions/new', label: 'New subscription' },
 ];
 
 export const routes = [
@@ -35,37 +20,18 @@ export const routes = [
     element: <MainLayout />,
     children: [
       { index: true, element: <LandingPage /> },
-      { path: 'auth/chzzk/login', element: <ChzzkLoginPage /> },
-      { path: 'auth/chzzk/callback', element: <ChzzkCallbackPage /> },
+      { path: 'login', element: <ChzzkLoginPage /> },
+      { path: 'auth/chzzk/login', element: <Navigate to="/login" replace /> },
       {
         element: <RequireAuth />,
         children: [
           {
-            path: 'app',
-            element: <SectionLayout title="Application" navItems={appNavItems} />,
+            path: 'subscriptions',
+            element: <SectionLayout title="Subscriptions" navItems={subscriptionNavItems} />,
             children: [
-              { index: true, element: <Navigate to="dashboard" replace /> },
-              { path: 'dashboard', element: <DashboardPage /> },
-              { path: 'subscriptions', element: <SubscriptionsPage /> },
-              { path: 'subscriptions/new', element: <NewSubscriptionPage /> },
-              { path: 'subscriptions/:id', element: <SubscriptionDetailPage /> },
-              { path: 'settings/account', element: <AccountSettingsPage /> },
-            ],
-          },
-        ],
-      },
-      {
-        element: <RequireAdmin />,
-        children: [
-          {
-            path: 'admin',
-            element: <SectionLayout title="Administration" navItems={adminNavItems} />,
-            children: [
-              { index: true, element: <Navigate to="users" replace /> },
-              { path: 'users', element: <AdminUsersPage /> },
-              { path: 'users/:id', element: <AdminUserDetailPage /> },
-              { path: 'subscriptions', element: <AdminSubscriptionsPage /> },
-              { path: 'audit-logs', element: <AdminAuditLogsPage /> },
+              { index: true, element: <SubscriptionsPage /> },
+              { path: 'new', element: <NewSubscriptionPage /> },
+              { path: ':id', element: <SubscriptionDetailPage /> },
             ],
           },
         ],

--- a/frontend/src/test/router.test.tsx
+++ b/frontend/src/test/router.test.tsx
@@ -1,31 +1,108 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { clearSession, setMockSession } from '../auth/session';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthProvider } from '../auth/AuthContext';
+import { clearSession } from '../auth/session';
 import { routes } from '../router';
 
 describe('router scaffold', () => {
   beforeEach(() => {
     clearSession();
+    window.localStorage.clear();
+    vi.restoreAllMocks();
   });
 
-  it('redirects guests to landing for protected app routes', async () => {
-    const router = createMemoryRouter(routes, {
-      initialEntries: ['/app/dashboard'],
-    });
-
-    render(<RouterProvider router={router} />);
-    expect(await screen.findByRole('heading', { name: 'Chzzk Event to Discord' })).toBeInTheDocument();
-    expect(router.state.location.pathname).toBe('/');
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('renders dashboard for authenticated users', async () => {
-    setMockSession('USER');
+  function renderWithSession(initialEntry: string) {
     const router = createMemoryRouter(routes, {
-      initialEntries: ['/app/dashboard'],
+      initialEntries: [initialEntry],
     });
 
-    render(<RouterProvider router={router} />);
-    expect(await screen.findByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
+    const view = render(
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>,
+    );
+
+    return { view, router };
+  }
+
+  function jsonResponse(status: number, body: unknown) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  function mockAuthMe(status: number, body: object = {}) {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/auth/me')) {
+        return jsonResponse(status, body);
+      }
+      if (url.includes('/auth/chzzk/login')) {
+        return jsonResponse(200, { authorizationUrl: 'https://auth.example/login' });
+      }
+      if (url.includes('/subscriptions')) {
+        return jsonResponse(200, { content: [], first: true, last: true, number: 0, size: 10, totalElements: 0, totalPages: 1 });
+      }
+      return jsonResponse(200, {});
+    });
+  }
+
+  it('redirects unauthenticated users from protected /subscriptions routes', async () => {
+    mockAuthMe(401, { message: 'Unauthorized' });
+
+    const { router } = renderWithSession('/subscriptions');
+    expect(await screen.findByRole('heading', { name: 'Login' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/login');
+    });
+    expect(globalThis.fetch).toHaveBeenCalled();
+    const firstCall = vi.mocked(globalThis.fetch).mock.calls[0]?.[0];
+    expect(String(firstCall)).toContain(
+      '/auth/me',
+    );
+  });
+
+  it('redirects to authorization URL from /login', async () => {
+    mockAuthMe(401, { message: 'Unauthorized' });
+
+    const originalLocation = window.location;
+    const hrefSpy = vi.fn();
+    const mockLocation = Object.create(originalLocation) as Location;
+
+    Object.defineProperty(mockLocation, 'href', {
+      configurable: true,
+      get() {
+        return hrefSpy.mock.lastCall?.[0] ?? originalLocation.href;
+      },
+      set(value: string) {
+        hrefSpy(String(value));
+      },
+    });
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: mockLocation,
+    });
+
+    try {
+      renderWithSession('/login');
+      const button = await screen.findByRole('button', { name: 'Login with Chzzk' });
+      await userEvent.click(button);
+      await waitFor(() => {
+        expect(hrefSpy).toHaveBeenCalledWith('https://auth.example/login');
+      });
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
   });
 });


### PR DESCRIPTION
Adds frontend auth/session handling + subscription CRUD UI.

Routes:
- /login
- /auth/chzzk/callback
- /subscriptions (guarded)
- /subscriptions/new (guarded)
- /subscriptions/:id (guarded)

Uses:
- VITE_API_BASE_URL (default http://localhost:8080/api/v1)

Verified:
- cd frontend && yarn install && yarn test && yarn build