### PR TITLE
ops: add compose and frontend nginx container

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,38 @@
+name: Frontend Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-tests.yml"
+
+jobs:
+  frontend-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: yarn install
+
+      - name: Lint frontend
+        working-directory: frontend
+        run: yarn lint
+
+      - name: Test frontend
+        working-directory: frontend
+        run: yarn test
+
+      - name: Build frontend
+        working-directory: frontend
+        run: yarn build

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@
 ## Docker Image
 Docker Image: ghcr.io/shin6949/chzzk-event-to-discord:latest
 
+## Deployment
+
+- Compose-based FE/BE deployment notes: `docs/DEPLOY.md`
+
 ## Notice
 아직 Chzzk의 정식 API가 나오지 않은 관계로 일정 주기에 따라 API에 요청하여 시간 단위로 데이터를 비교하여 이벤트를 전송하고 있습니다.  
 이 Application은 설정한 주기에 따라 API에 요청을 보냅니다. 서버에 부하를 주지 않기 위해 Database에 데이터를 일부 캐싱하는 등의 방법을 사용 중이지만, 너무 짧은 주기로 설정할 경우 서버에 부하를 줄 수 있으며, 차단될 수 있습니다.   

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.flywaydb:flyway-core'
     implementation 'dev.akkinoc.util:yaml-resource-bundle:2.15.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     compileOnly 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: chzzk-event-to-discord-backend:latest
+    container_name: chzzk-event-to-discord-backend
+    ports:
+      - "8080:8080"
+    environment:
+      APP_DB_DRIVER: ${APP_DB_DRIVER}
+      APP_DB_URL: ${APP_DB_URL}
+      APP_DB_USER: ${APP_DB_USER}
+      APP_DB_PASSWORD: ${APP_DB_PASSWORD}
+      CHZZK_OAUTH_CLIENT_ID: ${CHZZK_OAUTH_CLIENT_ID}
+      CHZZK_OAUTH_CLIENT_SECRET: ${CHZZK_OAUTH_CLIENT_SECRET}
+      CHZZK_OAUTH_REDIRECT_URI: ${CHZZK_OAUTH_REDIRECT_URI}
+      CHZZK_OAUTH_AUTH_BASE_URL: ${CHZZK_OAUTH_AUTH_BASE_URL:-https://chzzk.naver.com}
+      CHZZK_OAUTH_TOKEN_BASE_URL: ${CHZZK_OAUTH_TOKEN_BASE_URL:-https://openapi.chzzk.naver.com}
+      CHZZK_OAUTH_API_BASE_URL: ${CHZZK_OAUTH_API_BASE_URL:-https://openapi.chzzk.naver.com}
+      CHZZK_CHECK_INTERVAL: ${CHZZK_CHECK_INTERVAL:-30}
+      CHZZK_API_URL: ${CHZZK_API_URL:-https://api.chzzk.naver.com}
+      APP_INSERT_PASSWORD: ${APP_INSERT_PASSWORD:-}
+      APP_DEFAULT_TIMEZONE: ${APP_DEFAULT_TIMEZONE:-Asia/Seoul}
+      APP_IS_TEST: ${APP_IS_TEST:-false}
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://backend:8080/api/v1}
+    image: chzzk-event-to-discord-frontend:latest
+    container_name: chzzk-event-to-discord-frontend
+    ports:
+      - "3000:80"
+    environment:
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://backend:8080/api/v1}
+    depends_on:
+      - backend
+    restart: unless-stopped

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,63 @@
+# Production-ish Deploy Guide
+
+This repository supports separated frontend and backend containers for local/prod-ish runs.
+
+## Required environment variables
+
+Backend (Spring Boot) uses environment variables prefixed with `APP_` and `CHZZK_`:
+
+- `APP_DB_DRIVER` (required): JDBC driver class, e.g. `org.postgresql.Driver`
+- `APP_DB_URL` (required): JDBC URL
+- `APP_DB_USER` (required): DB user
+- `APP_DB_PASSWORD` (required): DB password
+- `CHZZK_OAUTH_CLIENT_ID` (required): OAuth client ID
+- `CHZZK_OAUTH_CLIENT_SECRET` (required): OAuth client secret
+- `CHZZK_OAUTH_REDIRECT_URI` (required): OAuth callback URI registered in Chzzk
+- `CHZZK_OAUTH_AUTH_BASE_URL` (optional): maps to `chzzk.oauth.auth-base-url`  
+  (default: `https://chzzk.naver.com`)
+- `CHZZK_OAUTH_TOKEN_BASE_URL` (optional): maps to `chzzk.oauth.token-base-url`  
+  (default: `https://openapi.chzzk.naver.com`)
+- `CHZZK_OAUTH_API_BASE_URL` (optional): maps to `chzzk.oauth.api-base-url`  
+  (default: `https://openapi.chzzk.naver.com`)
+
+Optional backend variables:
+
+- `CHZZK_CHECK_INTERVAL`: polling interval seconds (`CHZZK_CHECK_INTERVAL`)
+- `CHZZK_API_URL`: public CHZZK API URL override (`chzzk.api-url`)
+- `APP_INSERT_PASSWORD`: legacy insert API password
+- `APP_DEFAULT_TIMEZONE`, `APP_IS_TEST`
+
+Frontend container env:
+
+- `VITE_API_BASE_URL`: base URL for frontend API calls.
+  - In docker-compose on same network: `http://backend:8080/api/v1`
+  - For external public access, set to the reachable backend base URL.
+
+## Run with Docker Compose
+
+From repository root:
+
+```bash
+export APP_DB_DRIVER=org.postgresql.Driver
+export APP_DB_URL=jdbc:postgresql://<db-host>:5432/<db-name>
+export APP_DB_USER=<user>
+export APP_DB_PASSWORD=<password>
+export CHZZK_OAUTH_CLIENT_ID=<client id>
+export CHZZK_OAUTH_CLIENT_SECRET=<client secret>
+export CHZZK_OAUTH_REDIRECT_URI=<redirect uri>
+
+# optional but recommended for FE API endpoint in the container network
+export VITE_API_BASE_URL=http://backend:8080/api/v1
+
+docker compose up --build
+```
+
+Containers:
+
+- `backend`: exposes port 8080
+- `frontend`: serves static files with Nginx, exposes port 80 internally and maps to host port 3000 by default
+
+## Flyway / DB schema note (optional)
+
+If your deployment pipeline uses `flyway`, a baseline migration is provided for
+`chzzk_oauth_token` at `src/main/resources/db/migration/V1__create_chzzk_oauth_token.sql`.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+COPY . .
+
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
+RUN yarn build
+
+FROM nginx:1.27-alpine
+WORKDIR /usr/share/nginx/html
+RUN rm -rf ./*
+
+COPY --from=build /app/dist/ .
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "packageManager": "yarn@1.22.22",
   "scripts": {
     "dev": "vite",
+    "lint": "tsc --noEmit",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/src/main/resources/db/migration/V1__create_chzzk_oauth_token.sql
+++ b/src/main/resources/db/migration/V1__create_chzzk_oauth_token.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS chzzk_oauth_token (
+  channel_id VARCHAR(100) PRIMARY KEY,
+  access_token VARCHAR(3000) NOT NULL,
+  refresh_token VARCHAR(3000),
+  token_type VARCHAR(30),
+  scope VARCHAR(1000),
+  access_token_expires_at TIMESTAMP WITH TIME ZONE,
+  refresh_token_expires_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
Adds production-ish deploy scaffolding:
- frontend Dockerfile (multi-stage) served by nginx + SPA routing config
- docker-compose.yml with separate backend(front 8080) and frontend(3000:80)
- docs/DEPLOY.md describing env vars and compose run
- frontend CI workflow (yarn lint/test/build on frontend changes)
- optional Flyway dependency + migration for chzzk_oauth_token
