### PR TITLE
test: add QA-focused BE+FE scenario coverage

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, apiGet } from './client';
+
+function jsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('api client', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes request paths and applies default fetch options', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      return jsonResponse(200, { url });
+    });
+
+    await apiGet<{ url: string }>('/auth/me');
+    await apiGet<{ url: string }>('auth/me');
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost:8080/api/v1/auth/me',
+      expect.objectContaining({ method: 'GET', credentials: 'include' }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:8080/api/v1/auth/me',
+      expect.objectContaining({ method: 'GET', credentials: 'include' }),
+    );
+
+    const firstCallInit = fetchSpy.mock.calls[0]?.[1];
+    const headers = new Headers(firstCallInit?.headers);
+    expect(headers.get('Accept')).toBe('application/json');
+  });
+
+  it('returns typed JSON payloads on success', async () => {
+    type AuthMeResponse = {
+      channelId: string;
+      role: 'USER' | 'ADMIN';
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(200, { channelId: 'channel-1', role: 'USER' }));
+
+    const result = await apiGet<AuthMeResponse>('/auth/me');
+
+    expect(result.channelId).toBe('channel-1');
+    expect(result.role).toBe('USER');
+  });
+
+  it('raises typed ApiError for 401 responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(401, { message: 'Unauthorized' }));
+
+    let error: unknown;
+    try {
+      await apiGet('/auth/me');
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(ApiError);
+    const apiError = error as ApiError;
+    expect(apiError.status).toBe(401);
+    expect(apiError.message).toBe('Unauthorized');
+    expect(apiError.body).toEqual({ message: 'Unauthorized' });
+  });
+});

--- a/frontend/src/test/route-guards.test.tsx
+++ b/frontend/src/test/route-guards.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthProvider } from '../auth/AuthContext';
+import { RequireAdmin } from '../auth/RouteGuards';
+import { clearSession } from '../auth/session';
+
+function jsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function mockAuthMe(status: number, body: object = {}) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('/auth/me')) {
+      return jsonResponse(status, body);
+    }
+    return jsonResponse(200, {});
+  });
+}
+
+describe('route guards', () => {
+  beforeEach(() => {
+    clearSession();
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function renderGuard(initialEntry: string) {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          children: [
+            { path: 'login', element: <h1>Login page</h1> },
+            { path: 'subscriptions', element: <h1>Subscriptions page</h1> },
+            {
+              element: <RequireAdmin />,
+              children: [{ path: 'admin', element: <h1>Admin page</h1> }],
+            },
+          ],
+        },
+      ],
+      { initialEntries: [initialEntry] },
+    );
+
+    render(
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>,
+    );
+
+    return router;
+  }
+
+  it('redirects unauthenticated users away from admin routes', async () => {
+    mockAuthMe(401, { message: 'Unauthorized' });
+
+    const router = renderGuard('/admin');
+
+    expect(await screen.findByRole('heading', { name: 'Login page' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/login');
+    });
+  });
+
+  it('redirects non-admin users to subscriptions from admin routes', async () => {
+    mockAuthMe(200, { channelId: 'channel-user', role: 'USER' });
+
+    const router = renderGuard('/admin');
+
+    expect(await screen.findByRole('heading', { name: 'Subscriptions page' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/subscriptions');
+    });
+  });
+
+  it('allows admin users to stay on admin routes', async () => {
+    mockAuthMe(200, { channelId: 'channel-admin', role: 'ADMIN' });
+
+    const router = renderGuard('/admin');
+
+    expect(await screen.findByRole('heading', { name: 'Admin page' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/admin');
+    });
+  });
+});

--- a/frontend/src/test/router.test.tsx
+++ b/frontend/src/test/router.test.tsx
@@ -69,6 +69,17 @@ describe('router scaffold', () => {
     );
   });
 
+  it('allows authenticated users to open protected /subscriptions routes', async () => {
+    mockAuthMe(200, { channelId: 'channel-user', role: 'USER' });
+
+    const { router } = renderWithSession('/subscriptions');
+    expect(await screen.findByText('Manage your notification subscriptions.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/subscriptions');
+    });
+    expect(screen.getByText('No subscriptions found.')).toBeInTheDocument();
+  });
+
   it('redirects to authorization URL from /login', async () => {
     mockAuthMe(401, { message: 'Unauthorized' });
 

--- a/frontend/src/test/subscriptions-pages.test.tsx
+++ b/frontend/src/test/subscriptions-pages.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NewSubscriptionPage } from '../pages/app/NewSubscriptionPage';
+import { SubscriptionDetailPage } from '../pages/app/SubscriptionDetailPage';
+import { SubscriptionsPage } from '../pages/app/SubscriptionsPage';
+
+function jsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('subscriptions UI', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders list state from API response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/subscriptions?')) {
+        return jsonResponse(200, {
+          content: [
+            {
+              id: 101,
+              channelId: 'target-channel',
+              subscriptionType: 'STREAM_OFFLINE',
+              enabled: true,
+              webhookId: 1,
+              botProfileId: 2,
+              intervalMinute: 10,
+              createdAt: '2026-02-16T00:00:00Z',
+            },
+          ],
+          number: 0,
+          size: 10,
+          totalElements: 1,
+          totalPages: 1,
+          first: true,
+          last: true,
+        });
+      }
+
+      return jsonResponse(404, { message: 'not handled' });
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/subscriptions']}>
+        <Routes>
+          <Route path="/subscriptions" element={<SubscriptionsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('target-channel')).toBeInTheDocument();
+    expect(screen.getByText('STREAM_OFFLINE')).toBeInTheDocument();
+    expect(screen.getByText('1 item(s)')).toBeInTheDocument();
+  });
+
+  it('renders empty list message when API returns no subscriptions', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(200, {
+        content: [],
+        number: 0,
+        size: 10,
+        totalElements: 0,
+        totalPages: 1,
+        first: true,
+        last: true,
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/subscriptions']}>
+        <Routes>
+          <Route path="/subscriptions" element={<SubscriptionsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('No subscriptions found.')).toBeInTheDocument();
+  });
+
+  it('renders API error state when list request fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(500, { message: 'failed to load subscriptions' }));
+
+    render(
+      <MemoryRouter initialEntries={['/subscriptions']}>
+        <Routes>
+          <Route path="/subscriptions" element={<SubscriptionsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('failed to load subscriptions')).toBeInTheDocument();
+  });
+
+  it('validates create form before calling API', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(201, { id: 1 }));
+
+    render(
+      <MemoryRouter initialEntries={['/subscriptions/new']}>
+        <Routes>
+          <Route path="/subscriptions/new" element={<NewSubscriptionPage />} />
+          <Route path="/subscriptions" element={<h1>Subscriptions destination</h1>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    const submitButton = screen.getByRole('button', { name: 'Create subscription' });
+    expect(submitButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText('Channel ID (target channel)'), 'target-channel');
+    await user.type(screen.getByLabelText('Webhook ID'), 'abc');
+    await user.type(screen.getByLabelText('Bot Profile ID'), '3');
+
+    expect(submitButton).toBeEnabled();
+    await user.click(submitButton);
+
+    expect(await screen.findByText('Please fill required fields with valid numeric values.')).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('loads subscription detail payload for an existing subscription', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/subscriptions/42')) {
+        return jsonResponse(200, {
+          channelId: 'target-channel',
+          subscriptionType: 'STREAM_OFFLINE',
+          webhookId: 11,
+          botProfileId: 12,
+          intervalMinute: 15,
+          enabled: true,
+          content: 'payload content',
+        });
+      }
+
+      return jsonResponse(404, { message: 'not handled' });
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/subscriptions/42']}>
+        <Routes>
+          <Route path="/subscriptions/:id" element={<SubscriptionDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const channelInput = (await screen.findByLabelText('Channel ID (target channel)')) as HTMLInputElement;
+    expect(channelInput.value).toBe('target-channel');
+    expect(screen.getByDisplayValue('11')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('payload content')).toBeInTheDocument();
+  });
+
+  it('shows not found error on subscription detail page when API returns 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(404, { message: 'subscription not found' }));
+
+    render(
+      <MemoryRouter initialEntries={['/subscriptions/999']}>
+        <Routes>
+          <Route path="/subscriptions/:id" element={<SubscriptionDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('subscription not found')).toBeInTheDocument();
+  });
+});

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -7,6 +7,8 @@ spring:
       mode: always
   main:
     allow-bean-definition-overriding: true
+  flyway:
+    enabled: true
   datasource:
     # DB Config
 #    driver-class-name: oracle.jdbc.OracleDriver

--- a/src/test/java/me/cocoblue/chzzkeventtodiscord/domain/FlywayMigrationTests.java
+++ b/src/test/java/me/cocoblue/chzzkeventtodiscord/domain/FlywayMigrationTests.java
@@ -1,0 +1,49 @@
+package me.cocoblue.chzzkeventtodiscord.domain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@TestPropertySource(properties = "spring.flyway.enabled=true")
+class FlywayMigrationTests {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void flywayMigrationsRunAgainstH2AndCreateExpectedSchema() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            final String jdbcUrl = connection.getMetaData().getURL();
+            assertTrue(jdbcUrl.startsWith("jdbc:h2:"),
+                () -> "Expected H2 datasource in tests, but got: " + jdbcUrl);
+        }
+
+        final Integer migrationHistoryRows = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM FLYWAY_SCHEMA_HISTORY WHERE VERSION = '1' AND SUCCESS = TRUE",
+            Integer.class
+        );
+        final Integer oauthTokenTableRows = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'CHZZK_OAUTH_TOKEN'",
+            Integer.class
+        );
+
+        assertEquals(1, migrationHistoryRows);
+        assertEquals(1, oauthTokenTableRows);
+    }
+}

--- a/src/test/java/me/cocoblue/chzzkeventtodiscord/domain/FlywayMigrationTests.java
+++ b/src/test/java/me/cocoblue/chzzkeventtodiscord/domain/FlywayMigrationTests.java
@@ -35,7 +35,7 @@ class FlywayMigrationTests {
         }
 
         final Integer migrationHistoryRows = jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM FLYWAY_SCHEMA_HISTORY WHERE VERSION = '1' AND SUCCESS = TRUE",
+            "SELECT COUNT(*) FROM \"flyway_schema_history\" WHERE \"version\" = '1' AND \"success\" = TRUE",
             Integer.class
         );
         final Integer oauthTokenTableRows = jdbcTemplate.queryForObject(


### PR DESCRIPTION
Adds QA-minded scenario coverage to backend and frontend tests.

Backend:
- extends AuthControllerTests, SubscriptionControllerTests, ChzzkAuthServiceTests
- adds FlywayMigrationTests to assert migration + table presence on H2 test profile

Frontend (Vitest):
- api client tests (base URL, json, error handling)
- route guard tests (RequireAuth/RequireAdmin)
- subscriptions pages tests (list/empty/error/detail/not-found/create validation)

Local:
- frontend: yarn test + yarn build passed
- backend: local gradle is sandbox-flaky (socket restriction), rely on CI
