### PR TITLE
chore: ignore local test compose/env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ firebase-messaging-sw.js
 ./test.db
 *.env
 
+# Local-only Docker test stack files
+docker-compose.local.yml
+.env.local
+
 # Frontend/local security and build artifacts
 .env*
 *.pem


### PR DESCRIPTION
Adds .gitignore entries for local-only full-stack test files (docker-compose.local.yml, .env.local). These files exist only locally and must not be committed.